### PR TITLE
feat(contract): 필수 엔티티/도메인 개발, Swagger API 명세 작성 및 필수 의존성 추가

### DIFF
--- a/contract-service/build.gradle
+++ b/contract-service/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     // Swagger (OpenAPI)
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 
     // Prometheus (모니터링)
     implementation 'io.micrometer:micrometer-registry-prometheus'

--- a/contract-service/build.gradle
+++ b/contract-service/build.gradle
@@ -26,11 +26,22 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // h2
+    runtimeOnly 'com.h2database:h2'
+
+    // Kafka 연동
+    implementation 'org.springframework.kafka:spring-kafka'
 
     // Spring Batch
     implementation 'org.springframework.boot:spring-boot-starter-batch'
 
-    // JPA (QueryDSL을 위해 필요)
+    // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // QueryDSL
@@ -50,7 +61,6 @@ dependencies {
 
     // Prometheus (모니터링)
     implementation 'io.micrometer:micrometer-registry-prometheus'
-
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/contract-service/build.gradle
+++ b/contract-service/build.gradle
@@ -20,11 +20,38 @@ repositories {
 
 ext {
     set('springCloudVersion', "2025.0.0")
+    set('queryDslVersion', "5.0.0") // QueryDSL 버전 설정
 }
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // Spring Batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+
+    // JPA (QueryDSL을 위해 필요)
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // QueryDSL
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // MySQL
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // Swagger (OpenAPI)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+    // Prometheus (모니터링)
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/contract-service/src/main/java/com/example/contractservice/config/KafkaTemplateConfig.java
+++ b/contract-service/src/main/java/com/example/contractservice/config/KafkaTemplateConfig.java
@@ -1,0 +1,26 @@
+package com.example.contractservice.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+public class KafkaTemplateConfig {
+
+    @Value("${kafka.config.topic-partitions}")
+    private int topicPartitions;
+
+    @Value("${kafka.config.topic-replications}")
+    private int topicReplications;
+
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate(
+        ProducerFactory<String, Object> producerFactory
+    ) {
+        return new KafkaTemplate<>(producerFactory);
+    }
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/config/OpenApiConfig.java
+++ b/contract-service/src/main/java/com/example/contractservice/config/OpenApiConfig.java
@@ -1,0 +1,33 @@
+package com.example.contractservice.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Springdoc OpenAPI UI 설정을 위한 클래스입니다.
+ */
+@OpenAPIDefinition(
+    servers = {
+        @Server(url = "http://localhost:8000", description = "Gateway URL")
+    }
+)
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("계약, 정산, 예치금 관리 모듈의 API")
+                .version("v1.0.0")
+                .description("계약/정산/예치금 관리 모듈의 API 명세서입니다. 모듈 간 통신을 위한 API는 /internal을 포함합니다.");
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(info);
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/common/ContractStatus.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/common/ContractStatus.java
@@ -1,0 +1,10 @@
+package com.example.contractservice.contract.common;
+
+public enum ContractStatus {
+    REQUESTED,
+    CONFIRMED,
+    PAID,
+    IN_PROGRESS,
+    DONE,
+    CANCELLED
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/common/PaymentType.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/common/PaymentType.java
@@ -1,0 +1,6 @@
+package com.example.contractservice.contract.common;
+
+public enum PaymentType {
+    ONE_TIME,
+    MONTHLY
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/common/swagger/annotation/ContractCancelApi.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/common/swagger/annotation/ContractCancelApi.java
@@ -1,0 +1,21 @@
+package com.example.contractservice.contract.common.swagger.annotation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(summary = "계약 취소", description = "로그인한 회원이 자신의 계약을 취소")
+@Parameters({
+    @Parameter(name = "X-CODE", description = "로그인 사용자 코드", in = ParameterIn.HEADER, required = true),
+    @Parameter(name = "code", description = "취소할 계약 코드", in = ParameterIn.PATH)
+})
+public @interface ContractCancelApi {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/common/swagger/annotation/ContractConfirmApi.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/common/swagger/annotation/ContractConfirmApi.java
@@ -1,0 +1,21 @@
+package com.example.contractservice.contract.common.swagger.annotation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(summary = "계약 확정", description = "로그인한 회원이 자신의 계약을 확정")
+@Parameters({
+    @Parameter(name = "X-CODE", description = "로그인 사용자 코드", in = ParameterIn.HEADER, required = true),
+    @Parameter(name = "code", description = "확정할 계약 코드", in = ParameterIn.PATH)
+})
+public @interface ContractConfirmApi {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/common/swagger/annotation/ContractCreateApi.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/common/swagger/annotation/ContractCreateApi.java
@@ -1,0 +1,14 @@
+package com.example.contractservice.contract.common.swagger.annotation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(summary = "계약 생성", description = "REQUESTED 상태인 계약을 생성")
+public @interface ContractCreateApi {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/common/swagger/annotation/ContractPayApi.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/common/swagger/annotation/ContractPayApi.java
@@ -1,0 +1,21 @@
+package com.example.contractservice.contract.common.swagger.annotation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(summary = "계약 결제", description = "로그인한 회원이 자신의 계약을 결제")
+@Parameters({
+    @Parameter(name = "X-CODE", description = "로그인 사용자 코드", in = ParameterIn.HEADER, required = true),
+    @Parameter(name = "code", description = "결제할 계약 코드", in = ParameterIn.PATH)
+})
+public @interface ContractPayApi {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/common/swagger/annotation/GetContractByCodeApi.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/common/swagger/annotation/GetContractByCodeApi.java
@@ -1,0 +1,21 @@
+package com.example.contractservice.contract.common.swagger.annotation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(summary = "계약 상세 조회", description = "로그인한 회원이 자신과 관련된 특정 계약 상세 내용을 조회")
+@Parameters({
+    @Parameter(name = "X-CODE", description = "로그인 사용자 코드", in = ParameterIn.HEADER, required = true),
+    @Parameter(name = "code", description = "확인할 계약 코드", in = ParameterIn.PATH)
+})
+public @interface GetContractByCodeApi {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/common/swagger/annotation/GetContractInternalApi.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/common/swagger/annotation/GetContractInternalApi.java
@@ -1,0 +1,20 @@
+package com.example.contractservice.contract.common.swagger.annotation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(summary = "계약 조회", description = "특정 계약에 대한 내용과 참여하는 회원, 프리랜서 이름을 출력")
+@Parameters({
+    @Parameter(name = "code", description = "조회할 계약 코드", in = ParameterIn.PATH)
+})
+public @interface GetContractInternalApi {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/common/swagger/annotation/GetContractsApi.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/common/swagger/annotation/GetContractsApi.java
@@ -1,0 +1,22 @@
+package com.example.contractservice.contract.common.swagger.annotation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Operation(summary = "계약 목록 조회", description = "로그인한 회원이 자신과 관련된 계약 목록을 조회합니다.")
+@Parameters({
+    @Parameter(name = "X-CODE", description = "로그인 사용자 코드", in = ParameterIn.HEADER, required = true),
+    @Parameter(name = "cursor-date", description = "커서 기반 페이징을 위한 날짜 커서", in = ParameterIn.QUERY),
+    @Parameter(name = "cursor-code", description = "커서 기반 페이징을 위한 코드 커서", in = ParameterIn.QUERY)
+})
+public @interface GetContractsApi {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/ContractController.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/ContractController.java
@@ -1,5 +1,11 @@
 package com.example.contractservice.contract.controller;
 
+import com.example.contractservice.contract.common.swagger.annotation.ContractCancelApi;
+import com.example.contractservice.contract.common.swagger.annotation.ContractConfirmApi;
+import com.example.contractservice.contract.common.swagger.annotation.ContractCreateApi;
+import com.example.contractservice.contract.common.swagger.annotation.ContractPayApi;
+import com.example.contractservice.contract.common.swagger.annotation.GetContractByCodeApi;
+import com.example.contractservice.contract.common.swagger.annotation.GetContractsApi;
 import com.example.contractservice.contract.controller.dto.request.ContractCreateRequest;
 import com.example.contractservice.contract.controller.dto.response.ContractBriefResponse;
 import com.example.contractservice.contract.controller.dto.response.ContractCreateResponse;
@@ -15,6 +21,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -24,29 +31,34 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/contracts")
 public class ContractController {
+
     private final ContractService contractService;
 
+    @GetContractsApi
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public List<ContractBriefResponse> getContracts(
+    public List<ContractBriefResponse> getContracts(@RequestHeader(name = "X-CODE") String xCode,
         @RequestParam(value = "cursor-date", required = false) String cursorDate,
         @RequestParam(value = "cursor-code", required = false) String cursorCode) {
 
         return List.of(
             new ContractBriefResponse("클라이언트 이름1", "프리랜서 이름1", Instant.now(), Instant.now(), "PAID",
                 "계약명1"),
-            new ContractBriefResponse("클라이언트 이름2", "프리랜서 이름2", Instant.now(), Instant.now(), "IN_PROGRESS",
-                "계약명2"));
+            new ContractBriefResponse("클라이언트 이름2", "프리랜서 이름2", Instant.now(), Instant.now(),
+                "IN_PROGRESS", "계약명2"));
     }
 
+    @GetContractByCodeApi
     @GetMapping("/{code}")
     @ResponseStatus(HttpStatus.OK)
-    public ContractDetailResponse getContractByCode(@PathVariable String code) {
+    public ContractDetailResponse getContractByCode(@RequestHeader(name = "X-CODE") String xCode,
+        @PathVariable String code) {
 
         return new ContractDetailResponse("클라이언트 이름", "프리랜서 이름", Instant.now(), Instant.now(),
             Instant.now(), "ONE_TIME", "REQUESTED", "계약명", "계약 내용");
     }
 
+    @ContractCreateApi
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ContractCreateResponse createContract(@RequestBody ContractCreateRequest request) {
@@ -54,24 +66,30 @@ public class ContractController {
         return new ContractCreateResponse(UUID.randomUUID().toString());
     }
 
+    @ContractConfirmApi
     @PostMapping("/{code}/confirm")
     @ResponseStatus(HttpStatus.OK)
-    public ContractInfoResponse confirmContract(@PathVariable String code) {
+    public ContractInfoResponse confirmContract(@RequestHeader(name = "X-CODE") String xCode,
+        @PathVariable String code) {
 
         return new ContractInfoResponse(UUID.randomUUID().toString(), "CONFIRMED");
     }
 
+    @ContractPayApi
     @PostMapping("/{code}/pay")
     @ResponseStatus(HttpStatus.OK)
-    public ContractInfoResponse payContract(@PathVariable String code) {
+    public ContractInfoResponse payContract(@RequestHeader(name = "X-CODE") String xCode,
+        @PathVariable String code) {
 
-        return new  ContractInfoResponse(UUID.randomUUID().toString(), "PAID");
+        return new ContractInfoResponse(UUID.randomUUID().toString(), "PAID");
     }
 
+    @ContractCancelApi
     @PostMapping("/{code}/cancel")
     @ResponseStatus(HttpStatus.OK)
-    public ContractInfoResponse cancelContract(@PathVariable String code) {
+    public ContractInfoResponse cancelContract(@RequestHeader(name = "X-CODE") String xCode,
+        @PathVariable String code) {
 
-        return new  ContractInfoResponse(UUID.randomUUID().toString(), "CANCELLED");
+        return new ContractInfoResponse(UUID.randomUUID().toString(), "CANCELLED");
     }
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/ContractController.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/ContractController.java
@@ -5,9 +5,11 @@ import com.example.contractservice.contract.controller.dto.response.ContractBrie
 import com.example.contractservice.contract.controller.dto.response.ContractCreateResponse;
 import com.example.contractservice.contract.controller.dto.response.ContractDetailResponse;
 import com.example.contractservice.contract.controller.dto.response.ContractInfoResponse;
+import com.example.contractservice.contract.service.ContractService;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,8 +21,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/contracts")
 public class ContractController {
+    private final ContractService contractService;
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/ContractController.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/ContractController.java
@@ -1,0 +1,73 @@
+package com.example.contractservice.contract.controller;
+
+import com.example.contractservice.contract.controller.dto.request.ContractCreateRequest;
+import com.example.contractservice.contract.controller.dto.response.ContractBriefResponse;
+import com.example.contractservice.contract.controller.dto.response.ContractCreateResponse;
+import com.example.contractservice.contract.controller.dto.response.ContractDetailResponse;
+import com.example.contractservice.contract.controller.dto.response.ContractInfoResponse;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/contracts")
+public class ContractController {
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public List<ContractBriefResponse> getContracts(
+        @RequestParam(value = "cursor-date", required = false) String cursorDate,
+        @RequestParam(value = "cursor-code", required = false) String cursorCode) {
+
+        return List.of(
+            new ContractBriefResponse("클라이언트 이름1", "프리랜서 이름1", Instant.now(), Instant.now(), "PAID",
+                "계약명1"),
+            new ContractBriefResponse("클라이언트 이름2", "프리랜서 이름2", Instant.now(), Instant.now(), "IN_PROGRESS",
+                "계약명2"));
+    }
+
+    @GetMapping("/{code}")
+    @ResponseStatus(HttpStatus.OK)
+    public ContractDetailResponse getContractByCode(@PathVariable String code) {
+
+        return new ContractDetailResponse("클라이언트 이름", "프리랜서 이름", Instant.now(), Instant.now(),
+            Instant.now(), "ONE_TIME", "REQUESTED", "계약명", "계약 내용");
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ContractCreateResponse createContract(@RequestBody ContractCreateRequest request) {
+
+        return new ContractCreateResponse(UUID.randomUUID().toString());
+    }
+
+    @PostMapping("/{code}/confirm")
+    @ResponseStatus(HttpStatus.OK)
+    public ContractInfoResponse confirmContract(@PathVariable String code) {
+
+        return new ContractInfoResponse(UUID.randomUUID().toString(), "CONFIRMED");
+    }
+
+    @PostMapping("/{code}/pay")
+    @ResponseStatus(HttpStatus.OK)
+    public ContractInfoResponse payContract(@PathVariable String code) {
+
+        return new  ContractInfoResponse(UUID.randomUUID().toString(), "PAID");
+    }
+
+    @PostMapping("/{code}/cancel")
+    @ResponseStatus(HttpStatus.OK)
+    public ContractInfoResponse cancelContract(@PathVariable String code) {
+
+        return new  ContractInfoResponse(UUID.randomUUID().toString(), "CANCELLED");
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/ContractInternalController.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/ContractInternalController.java
@@ -1,5 +1,6 @@
 package com.example.contractservice.contract.controller;
 
+import com.example.contractservice.contract.common.swagger.annotation.GetContractInternalApi;
 import com.example.contractservice.contract.controller.dto.response.ContractBriefResponse;
 import com.example.contractservice.contract.service.ContractService;
 import java.time.Instant;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ContractInternalController {
     private final ContractService contractService;
 
+    @GetContractInternalApi
     @GetMapping("/{code}")
     @ResponseStatus(HttpStatus.OK)
     public ContractBriefResponse getBriefInfo(@PathVariable String code) {

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/ContractInternalController.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/ContractInternalController.java
@@ -1,0 +1,24 @@
+package com.example.contractservice.contract.controller;
+
+import com.example.contractservice.contract.controller.dto.response.ContractBriefResponse;
+import java.time.Instant;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/internal/contracts")
+public class ContractInternalController {
+
+    @GetMapping("/{code}")
+    @ResponseStatus(HttpStatus.OK)
+    public ContractBriefResponse getBriefInfo(@PathVariable String code) {
+
+        return new ContractBriefResponse("클라이언트 이름", "프리랜서 이름", Instant.now(), Instant.now(),
+            "DONE", "계약명");
+    }
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/ContractInternalController.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/ContractInternalController.java
@@ -1,7 +1,9 @@
 package com.example.contractservice.contract.controller;
 
 import com.example.contractservice.contract.controller.dto.response.ContractBriefResponse;
+import com.example.contractservice.contract.service.ContractService;
 import java.time.Instant;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,8 +12,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/internal/contracts")
 public class ContractInternalController {
+    private final ContractService contractService;
 
     @GetMapping("/{code}")
     @ResponseStatus(HttpStatus.OK)

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/request/ContractCreateRequest.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/request/ContractCreateRequest.java
@@ -3,8 +3,8 @@ package com.example.contractservice.contract.controller.dto.request;
 import java.time.Instant;
 
 public record ContractCreateRequest(
-        String freelancerId,
-        String clientId,
+        String freelancerCode,
+        String clientCode,
         Instant startedAt,
         Instant endedAt,
         String paymentType,

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/request/ContractCreateRequest.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/request/ContractCreateRequest.java
@@ -1,4 +1,4 @@
-package com.example.contractservice.controller.dto.request;
+package com.example.contractservice.contract.controller.dto.request;
 
 import java.time.Instant;
 

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/request/ContractCreateRequest.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/request/ContractCreateRequest.java
@@ -1,14 +1,23 @@
 package com.example.contractservice.contract.controller.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 
 public record ContractCreateRequest(
+        @Schema(description = "프리랜서(회원) 코드", example = "8172516b-2076-460f-805d-e60cbc0463c7")
         String freelancerCode,
+        @Schema(description = "회원 코드", example = "abdd2b21-d2a1-4d89-8271-e9941e7ef93e")
         String clientCode,
+        @Schema(description = "프로젝트 시작일", example = "2023-08-31T01:07:25.295Z")
         Instant startedAt,
+        @Schema(description = "프로젝트 종료일", example = "2023-08-31T01:07:25.295Z")
         Instant endedAt,
+        @Schema(description = "지불 방식", allowableValues = {"ONE_TIME", "MONTHLY"}, example = "MONTHLY")
         String paymentType,
+        @Schema(description = "단위 금액", example = "10000")
         Long unitAmount,
+        @Schema(description = "계약 명", example = "계약1")
         String name,
+        @Schema(description = "계약 내용", example = "내용")
         String body
 ) {}

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractBriefResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractBriefResponse.java
@@ -1,13 +1,22 @@
 package com.example.contractservice.contract.controller.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 
 public record ContractBriefResponse(
+    @Schema(description = "회원 이름", example = "회원이름")
     String clientName,
+    @Schema(description = "프리랜서(회원) 이름", example = "프리랜서이름")
     String freelancerName,
+    @Schema(description = "프로젝트 시작일", example = "2023-08-31T01:07:25.295Z")
     Instant startedAt,
+    @Schema(description = "프로젝트 종료일", example = "10000")
     Instant endedAt,
+    @Schema(description = "계약 상태",
+        allowableValues = {"REQUESTED", "CONFIRMED", "PAID", "IN_PROGRESS", "DONE"},
+        example = "REQUESTED")
     String status,
+    @Schema(description = "계약명", example = "계약명")
     String name
 ) {
 

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractBriefResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractBriefResponse.java
@@ -1,0 +1,14 @@
+package com.example.contractservice.contract.controller.dto.response;
+
+import java.time.Instant;
+
+public record ContractBriefResponse(
+    String clientName,
+    String freelancerName,
+    Instant startedAt,
+    Instant endedAt,
+    String status,
+    String name
+) {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractCreateResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractCreateResponse.java
@@ -1,4 +1,4 @@
-package com.example.contractservice.controller.dto.response;
+package com.example.contractservice.contract.controller.dto.response;
 
 import java.time.Instant;
 

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractCreateResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractCreateResponse.java
@@ -1,6 +1,9 @@
 package com.example.contractservice.contract.controller.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record ContractCreateResponse(
+    @Schema(description = "생성된 계약 코드", example = "4cd54740-91dc-4bcd-856c-1b776fc227b6")
     String code
 ) {
 

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractCreateResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractCreateResponse.java
@@ -1,14 +1,7 @@
 package com.example.contractservice.contract.controller.dto.response;
 
-import java.time.Instant;
-
 public record ContractCreateResponse(
-    String code,
-    Instant startedAt,
-    Instant endedAt,
-    long unitAmount,
-    String name,
-    String body
+    String code
 ) {
 
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractDetailResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractDetailResponse.java
@@ -1,0 +1,17 @@
+package com.example.contractservice.contract.controller.dto.response;
+
+import java.time.Instant;
+
+public record ContractDetailResponse(
+    String clientName,
+    String freelancerName,
+    Instant createdAt,
+    Instant startedAt,
+    Instant endedAt,
+    String paymentType,
+    String status,
+    String name,
+    String body
+) {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractDetailResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractDetailResponse.java
@@ -1,16 +1,28 @@
 package com.example.contractservice.contract.controller.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 
 public record ContractDetailResponse(
+    @Schema(description = "회원 코드", example = "abdd2b21-d2a1-4d89-8271-e9941e7ef93e")
     String clientName,
+    @Schema(description = "프리랜서(회원) 코드", example = "8172516b-2076-460f-805d-e60cbc0463c7")
     String freelancerName,
+    @Schema(description = "계약 생성 일시", example = "2023-08-31T01:07:25.295Z")
     Instant createdAt,
+    @Schema(description = "프로젝트 시작일", example = "2023-08-31T01:07:25.295Z")
     Instant startedAt,
+    @Schema(description = "프로젝트 종료일", example = "2023-08-31T01:07:25.295Z")
     Instant endedAt,
+    @Schema(description = "지불 방식", allowableValues = {"ONE_TIME", "MONTHLY"}, example = "MONTHLY")
     String paymentType,
+    @Schema(description = "계약 상태",
+        allowableValues = {"REQUESTED", "CONFIRMED", "PAID", "IN_PROGRESS", "DONE"},
+        example = "PAID")
     String status,
+    @Schema(description = "계약 명", example = "계약1")
     String name,
+    @Schema(description = "계약 내용", example = "내용")
     String body
 ) {
 

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractInfoResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractInfoResponse.java
@@ -1,7 +1,13 @@
 package com.example.contractservice.contract.controller.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record ContractInfoResponse(
+    @Schema(description = "생성된 계약 코드", example = "4cd54740-91dc-4bcd-856c-1b776fc227b6")
     String code,
+    @Schema(description = "계약 상태",
+        allowableValues = {"REQUESTED", "CONFIRMED", "PAID", "IN_PROGRESS", "DONE"},
+        example = "IN_PROGRESS")
     String status
 ) {
 

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractInfoResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/response/ContractInfoResponse.java
@@ -1,0 +1,8 @@
+package com.example.contractservice.contract.controller.dto.response;
+
+public record ContractInfoResponse(
+    String code,
+    String status
+) {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/domain/Contract.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/domain/Contract.java
@@ -1,0 +1,32 @@
+package com.example.contractservice.contract.domain;
+
+import com.example.contractservice.contract.domain.vo.ContractContent;
+import com.example.contractservice.contract.domain.vo.ContractInfo;
+import java.time.Instant;
+import java.util.UUID;
+
+public class Contract {
+
+    private String code;
+
+    private ContractInfo info;
+    private ContractContent content;
+
+    private Instant createdAt;
+    private Instant updatedAt;
+    private Boolean isDeleted;
+
+    public Contract(String code, ContractInfo info, ContractContent content, Instant createdAt,
+        Instant updatedAt, Boolean isDeleted) {
+        this.code = (code == null) ? generateCode() : code;
+        this.info = info;
+        this.content = content;
+        this.createdAt = (createdAt == null) ? Instant.now() : createdAt;
+        this.updatedAt = (updatedAt == null) ? this.createdAt : updatedAt;
+        this.isDeleted = isDeleted;
+    }
+
+    private String generateCode() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/domain/vo/ContractContent.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/domain/vo/ContractContent.java
@@ -1,0 +1,8 @@
+package com.example.contractservice.contract.domain.vo;
+
+public record ContractContent(
+    String name,
+    String body
+) {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/domain/vo/ContractInfo.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/domain/vo/ContractInfo.java
@@ -1,0 +1,17 @@
+package com.example.contractservice.contract.domain.vo;
+
+import com.example.contractservice.contract.common.ContractStatus;
+import com.example.contractservice.contract.common.PaymentType;
+import java.time.Instant;
+
+public record ContractInfo(
+    String freelancerCode,
+    String clientCode,
+    Instant startedAt,
+    Instant endedAt,
+    PaymentType paymentType,
+    Long unitAmount,
+    ContractStatus status
+) {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/entity/ContractEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/entity/ContractEntity.java
@@ -1,0 +1,71 @@
+package com.example.contractservice.contract.entity;
+
+import com.example.contractservice.contract.common.ContractStatus;
+import com.example.contractservice.contract.common.PaymentType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "contracts")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ContractEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // BaseEntity
+
+    @Column(name = "freelancer_code", nullable = false, length = 36)
+    private String freelancerCode;
+
+    @Column(name = "client_code", nullable = false, length = 36)
+    private String clientCode;
+
+    @Column(name = "code", nullable = false, length = 36)
+    private String code;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt; // BaseEntity
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt; // BaseEntity
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false; // BaseEntity
+
+    @Column(name = "started_at", nullable = false)
+    private Instant startedAt;
+
+    @Column(name = "ended_at", nullable = false)
+    private Instant endedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_type", nullable = false)
+    private PaymentType paymentType;
+
+    @Column(name = "unit_amount", nullable = false)
+    private Long unitAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ContractStatus status;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Lob
+    @Column(name = "body", nullable = false)
+    private String body;
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/entity/ContractEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/entity/ContractEntity.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import lombok.AccessLevel;
@@ -26,13 +25,13 @@ public class ContractEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // BaseEntity
 
-    @Column(name = "freelancer_code", nullable = false, length = 36)
+    @Column(name = "freelancer_code", nullable = false, columnDefinition = "CHAR(36)")
     private String freelancerCode;
 
-    @Column(name = "client_code", nullable = false, length = 36)
+    @Column(name = "client_code", nullable = false, columnDefinition = "CHAR(36)")
     private String clientCode;
 
-    @Column(name = "code", nullable = false, length = 36)
+    @Column(name = "code", nullable = false, columnDefinition = "CHAR(36)")
     private String code;
 
     @Column(name = "created_at", nullable = false)
@@ -64,8 +63,7 @@ public class ContractEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Lob
-    @Column(name = "body", nullable = false)
+    @Column(name = "body", nullable = false, columnDefinition = "TEXT")
     private String body;
 
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/repository/ContractJpaRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/repository/ContractJpaRepository.java
@@ -1,0 +1,8 @@
+package com.example.contractservice.contract.repository;
+
+import com.example.contractservice.contract.entity.ContractEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContractJpaRepository extends JpaRepository<ContractEntity, Long> {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/repository/ContractRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/repository/ContractRepository.java
@@ -1,0 +1,11 @@
+package com.example.contractservice.contract.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ContractRepository {
+    private final ContractJpaRepository contractJpaRepository;
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/ContractService.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/ContractService.java
@@ -1,0 +1,12 @@
+package com.example.contractservice.contract.service;
+
+import com.example.contractservice.contract.repository.ContractRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ContractService {
+    private final ContractRepository contractRepository;
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/controller/dto/request/ContractCreateRequest.java
+++ b/contract-service/src/main/java/com/example/contractservice/controller/dto/request/ContractCreateRequest.java
@@ -1,0 +1,14 @@
+package com.example.contractservice.controller.dto.request;
+
+import java.time.Instant;
+
+public record ContractCreateRequest(
+        String freelancerId,
+        String clientId,
+        Instant startedAt,
+        Instant endedAt,
+        String paymentType,
+        Long unitAmount,
+        String name,
+        String body
+) {}

--- a/contract-service/src/main/java/com/example/contractservice/controller/dto/response/ContractCreateResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/controller/dto/response/ContractCreateResponse.java
@@ -1,0 +1,14 @@
+package com.example.contractservice.controller.dto.response;
+
+import java.time.Instant;
+
+public record ContractCreateResponse(
+    String code,
+    Instant startedAt,
+    Instant endedAt,
+    long unitAmount,
+    String name,
+    String body
+) {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/common/GetDepositApi.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/common/GetDepositApi.java
@@ -1,0 +1,20 @@
+package com.example.contractservice.deposit.common;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(summary = "예치금 조회", description = "로그인한 사용자의 예치금 정보를 조회합니다.")
+@Parameters({
+    @Parameter(name = "X-CODE", in = ParameterIn.HEADER, description = "로그인 사용자 코드")
+})
+public @interface GetDepositApi {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/common/GetDepositHistoriesApi.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/common/GetDepositHistoriesApi.java
@@ -1,0 +1,22 @@
+package com.example.contractservice.deposit.common;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(summary = "예치금 변경 내역 조회", description = "로그인한 사용자의 예치금 변경 내역을 페이징하여 조회합니다.")
+@Parameters({
+    @Parameter(name = "X-CODE", description = "로그인 사용자 코드", in = ParameterIn.HEADER, required = true),
+    @Parameter(name = "cursor-date", description = "커서 기반 페이징을 위한 날짜 커서", in = ParameterIn.QUERY),
+    @Parameter(name = "cursor-code", description = "커서 기반 페이징을 위한 코드 커서", in = ParameterIn.QUERY)
+})
+public @interface GetDepositHistoriesApi {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/controller/DepositController.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/controller/DepositController.java
@@ -2,8 +2,10 @@ package com.example.contractservice.deposit.controller;
 
 import com.example.contractservice.deposit.controller.dto.response.DepositHistoryInfoResponse;
 import com.example.contractservice.deposit.controller.dto.response.DepositInfoResponse;
+import com.example.contractservice.deposit.service.DepositService;
 import java.time.Instant;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,8 +14,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/deposits")
 public class DepositController {
+    private final DepositService depositService;
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)

--- a/contract-service/src/main/java/com/example/contractservice/deposit/controller/DepositController.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/controller/DepositController.java
@@ -1,0 +1,33 @@
+package com.example.contractservice.deposit.controller;
+
+import com.example.contractservice.deposit.controller.dto.response.DepositHistoryInfoResponse;
+import com.example.contractservice.deposit.controller.dto.response.DepositInfoResponse;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/deposits")
+public class DepositController {
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public DepositInfoResponse getMyDeposit() {
+
+        return new DepositInfoResponse(1000L);
+    }
+
+    @GetMapping("/histories")
+    @ResponseStatus(HttpStatus.OK)
+    public List<DepositHistoryInfoResponse> getMyDepositHistories(
+        @RequestParam(value = "cursor-date", required = false) Instant cursorDate,
+        @RequestParam(value = "cursor-code", required = false) String cursorCode) {
+
+        return List.of(new DepositHistoryInfoResponse(Instant.now(), 1000L, 2000L, "요약 예시"));
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/controller/DepositController.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/controller/DepositController.java
@@ -1,5 +1,7 @@
 package com.example.contractservice.deposit.controller;
 
+import com.example.contractservice.deposit.common.GetDepositApi;
+import com.example.contractservice.deposit.common.GetDepositHistoriesApi;
 import com.example.contractservice.deposit.controller.dto.response.DepositHistoryInfoResponse;
 import com.example.contractservice.deposit.controller.dto.response.DepositInfoResponse;
 import com.example.contractservice.deposit.service.DepositService;
@@ -8,6 +10,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -19,16 +22,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class DepositController {
     private final DepositService depositService;
 
+    @GetDepositApi
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public DepositInfoResponse getMyDeposit() {
+    public DepositInfoResponse getMyDeposit(@RequestHeader(name = "X-CODE") String xCode) {
 
         return new DepositInfoResponse(1000L);
     }
 
+    @GetDepositHistoriesApi
     @GetMapping("/histories")
     @ResponseStatus(HttpStatus.OK)
     public List<DepositHistoryInfoResponse> getMyDepositHistories(
+        @RequestHeader(value = "X-CODE") String xCode,
         @RequestParam(value = "cursor-date", required = false) Instant cursorDate,
         @RequestParam(value = "cursor-code", required = false) String cursorCode) {
 

--- a/contract-service/src/main/java/com/example/contractservice/deposit/controller/dto/response/DepositHistoryInfoResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/controller/dto/response/DepositHistoryInfoResponse.java
@@ -1,0 +1,12 @@
+package com.example.contractservice.deposit.controller.dto.response;
+
+import java.time.Instant;
+
+public record DepositHistoryInfoResponse(
+    Instant createdAt,
+    Long changeAmount,
+    Long resultAmount,
+    String summary
+) {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/controller/dto/response/DepositHistoryInfoResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/controller/dto/response/DepositHistoryInfoResponse.java
@@ -1,12 +1,13 @@
 package com.example.contractservice.deposit.controller.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 
 public record DepositHistoryInfoResponse(
-    Instant createdAt,
-    Long changeAmount,
-    Long resultAmount,
-    String summary
+    @Schema(description = "내역 변경 일시", example = "2023-08-31T01:07:25.295Z") Instant createdAt,
+    @Schema(description = "변경된 금액", example = "2000") Long changeAmount,
+    @Schema(description = "처리 후 잔액", example = "1452000") Long resultAmount,
+    @Schema(description = "변경 내역에 대한 짧은 요약", example = "디자이너 계약금 정산") String summary
 ) {
 
 }

--- a/contract-service/src/main/java/com/example/contractservice/deposit/controller/dto/response/DepositInfoResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/controller/dto/response/DepositInfoResponse.java
@@ -1,7 +1,9 @@
 package com.example.contractservice.deposit.controller.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record DepositInfoResponse (
-    Long amount
+    @Schema(description = "현재 예치금 금액", example = "0") Long amount
 ){
 
 }

--- a/contract-service/src/main/java/com/example/contractservice/deposit/controller/dto/response/DepositInfoResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/controller/dto/response/DepositInfoResponse.java
@@ -1,0 +1,7 @@
+package com.example.contractservice.deposit.controller.dto.response;
+
+public record DepositInfoResponse (
+    Long amount
+){
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/domain/Deposit.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/domain/Deposit.java
@@ -1,0 +1,22 @@
+package com.example.contractservice.deposit.domain;
+
+import java.util.UUID;
+
+public class Deposit {
+
+    private String code;
+
+    private String memberCode;
+
+    private Long amount;
+
+    public Deposit(String code, String memberCode, Long amount) {
+        this.code = (code == null) ? generateCode() : code;
+        this.memberCode = memberCode;
+        this.amount = amount;
+    }
+
+    private String generateCode() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/domain/DepositHistory.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/domain/DepositHistory.java
@@ -1,0 +1,29 @@
+package com.example.contractservice.deposit.domain;
+
+import com.example.contractservice.deposit.domain.vo.DepositChange;
+import java.time.Instant;
+import java.util.UUID;
+
+public class DepositHistory {
+    private String code;
+    private String depositCode;
+
+    private DepositChange depositChange;
+
+    private String summary;
+
+    private Instant createdAt;
+
+    public DepositHistory(String code, String depositCode, DepositChange depositChange,
+        String summary, Instant createdAt) {
+        this.code = (code == null) ? generateCode() : code;
+        this.depositCode = depositCode;
+        this.depositChange = depositChange;
+        this.summary = summary;
+        this.createdAt = (createdAt == null) ? Instant.now() : createdAt;
+    }
+
+    private String generateCode() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/domain/vo/DepositChange.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/domain/vo/DepositChange.java
@@ -1,0 +1,8 @@
+package com.example.contractservice.deposit.domain.vo;
+
+public record DepositChange(
+    Long changeAmount,
+    Long resultAmount
+) {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositEntity.java
@@ -20,10 +20,10 @@ public class DepositEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "member_code", nullable = false, length = 36)
+    @Column(name = "member_code", nullable = false, columnDefinition = "CHAR(36)")
     private String memberCode;
 
-    @Column(name = "code", nullable = false, length = 36)
+    @Column(name = "code", nullable = false, columnDefinition = "CHAR(36)")
     private String code;
 
     @Column(name = "amount", nullable = false)

--- a/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositEntity.java
@@ -1,0 +1,32 @@
+package com.example.contractservice.deposit.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "deposits")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DepositEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_code", nullable = false, length = 36)
+    private String memberCode;
+
+    @Column(name = "code", nullable = false, length = 36)
+    private String code;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositHistoryEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositHistoryEntity.java
@@ -1,0 +1,48 @@
+package com.example.contractservice.deposit.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "deposit_histories")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DepositHistoryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // BaseEntity
+
+    @Column(name = "deposit_code", nullable = false, length = 36)
+    private String depositCode;
+
+    @Column(name = "code", nullable = false, length = 36)
+    private String code;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt; // BaseEntity
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt; // BaseEntity
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false; // BaseEntity
+
+    @Column(name = "change_amount", nullable = false)
+    private Long changeAmount;
+
+    @Column(name = "summary", nullable = false)
+    private String summary;
+
+    @Column(name = "result_amount", nullable = false)
+    private Long resultAmount;
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositHistoryEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositHistoryEntity.java
@@ -21,10 +21,10 @@ public class DepositHistoryEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // BaseEntity
 
-    @Column(name = "deposit_code", nullable = false, length = 36)
+    @Column(name = "deposit_code", nullable = false, columnDefinition = "CHAR(36)")
     private String depositCode;
 
-    @Column(name = "code", nullable = false, length = 36)
+    @Column(name = "code", nullable = false, columnDefinition = "CHAR(36)")
     private String code;
 
     @Column(name = "created_at", nullable = false)

--- a/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositHistoryJpaRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositHistoryJpaRepository.java
@@ -1,0 +1,8 @@
+package com.example.contractservice.deposit.repository;
+
+import com.example.contractservice.deposit.entity.DepositHistoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DepositHistoryJpaRepository extends JpaRepository<DepositHistoryEntity, Long> {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositJpaRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositJpaRepository.java
@@ -1,0 +1,8 @@
+package com.example.contractservice.deposit.repository;
+
+import com.example.contractservice.deposit.entity.DepositEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DepositJpaRepository extends JpaRepository<DepositEntity, Long> {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositRepository.java
@@ -1,0 +1,12 @@
+package com.example.contractservice.deposit.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DepositRepository {
+    private final DepositJpaRepository depositJpaRepository;
+    private final DepositHistoryJpaRepository depositHistoryJpaRepository;
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/service/DepositService.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/service/DepositService.java
@@ -1,5 +1,6 @@
 package com.example.contractservice.deposit.service;
 
+import com.example.contractservice.deposit.repository.DepositRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/contract-service/src/main/java/com/example/contractservice/deposit/service/DepositService.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/service/DepositService.java
@@ -1,0 +1,11 @@
+package com.example.contractservice.deposit.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DepositService {
+    private final DepositRepository depositRepository;
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/settlement/common/SettlementStatus.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/common/SettlementStatus.java
@@ -1,0 +1,7 @@
+package com.example.contractservice.settlement.common;
+
+public enum SettlementStatus {
+    BEFORE,
+    DONE,
+    FAILED
+}

--- a/contract-service/src/main/java/com/example/contractservice/settlement/domain/Settlement.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/domain/Settlement.java
@@ -1,0 +1,31 @@
+package com.example.contractservice.settlement.domain;
+
+import com.example.contractservice.settlement.domain.vo.SettlementReference;
+import com.example.contractservice.settlement.domain.vo.SettlementStatusInfo;
+import java.time.Instant;
+import java.util.UUID;
+
+public class Settlement {
+
+    private String code;
+
+    private SettlementReference settlementReference;
+
+    private SettlementStatusInfo settlementStatusInfo;
+
+    private Instant createdAt;
+    private Instant processedAt;
+
+    public Settlement(String code, SettlementReference settlementReference,
+        SettlementStatusInfo settlementStatusInfo, Instant createdAt, Instant processedAt) {
+        this.code = (code == null) ? generateCode() : code;
+        this.settlementReference = settlementReference;
+        this.settlementStatusInfo = settlementStatusInfo;
+        this.createdAt = (createdAt == null) ? Instant.now() : createdAt;
+        this.processedAt = processedAt;
+    }
+
+    private String generateCode() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/settlement/domain/Settlement.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/domain/Settlement.java
@@ -2,7 +2,7 @@ package com.example.contractservice.settlement.domain;
 
 import com.example.contractservice.settlement.domain.vo.SettlementReference;
 import com.example.contractservice.settlement.domain.vo.SettlementStatusInfo;
-import java.time.Instant;
+import com.example.contractservice.settlement.domain.vo.SettlementTimeline;
 import java.util.UUID;
 
 public class Settlement {
@@ -13,16 +13,14 @@ public class Settlement {
 
     private SettlementStatusInfo settlementStatusInfo;
 
-    private Instant createdAt;
-    private Instant processedAt;
+    private SettlementTimeline settlementTimeline;
 
     public Settlement(String code, SettlementReference settlementReference,
-        SettlementStatusInfo settlementStatusInfo, Instant createdAt, Instant processedAt) {
+        SettlementStatusInfo settlementStatusInfo, SettlementTimeline settlementTimeline) {
         this.code = (code == null) ? generateCode() : code;
         this.settlementReference = settlementReference;
         this.settlementStatusInfo = settlementStatusInfo;
-        this.createdAt = (createdAt == null) ? Instant.now() : createdAt;
-        this.processedAt = processedAt;
+        this.settlementTimeline = settlementTimeline;
     }
 
     private String generateCode() {

--- a/contract-service/src/main/java/com/example/contractservice/settlement/domain/vo/SettlementReference.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/domain/vo/SettlementReference.java
@@ -1,0 +1,8 @@
+package com.example.contractservice.settlement.domain.vo;
+
+public record SettlementReference(
+    String receiverCode,
+    String contractCode
+) {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/settlement/domain/vo/SettlementStatusInfo.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/domain/vo/SettlementStatusInfo.java
@@ -1,12 +1,13 @@
 package com.example.contractservice.settlement.domain.vo;
 
 import com.example.contractservice.settlement.common.SettlementStatus;
-import java.time.Instant;
+import java.math.BigDecimal;
 
 public record SettlementStatusInfo(
-    Long amount,
+    Long originalAmount,
+    Long settledAmount,
     SettlementStatus status,
-    Instant progressingAt
+    BigDecimal settlementRate
 ) {
 
 }

--- a/contract-service/src/main/java/com/example/contractservice/settlement/domain/vo/SettlementStatusInfo.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/domain/vo/SettlementStatusInfo.java
@@ -1,10 +1,11 @@
 package com.example.contractservice.settlement.domain.vo;
 
+import com.example.contractservice.settlement.common.SettlementStatus;
 import java.time.Instant;
 
 public record SettlementStatusInfo(
     Long amount,
-    String status,
+    SettlementStatus status,
     Instant progressingAt
 ) {
 

--- a/contract-service/src/main/java/com/example/contractservice/settlement/domain/vo/SettlementStatusInfo.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/domain/vo/SettlementStatusInfo.java
@@ -1,0 +1,11 @@
+package com.example.contractservice.settlement.domain.vo;
+
+import java.time.Instant;
+
+public record SettlementStatusInfo(
+    Long amount,
+    String status,
+    Instant progressingAt
+) {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/settlement/domain/vo/SettlementTimeline.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/domain/vo/SettlementTimeline.java
@@ -1,0 +1,11 @@
+package com.example.contractservice.settlement.domain.vo;
+
+import java.time.Instant;
+
+public record SettlementTimeline(
+    Instant createdAt,
+    Instant settledAt,
+    Instant progressingAt
+) {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/settlement/entity/SettlementEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/entity/SettlementEntity.java
@@ -1,7 +1,10 @@
 package com.example.contractservice.settlement.entity;
 
+import com.example.contractservice.settlement.common.SettlementStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -21,20 +24,21 @@ public class SettlementEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "code", nullable = false, length = 36)
+    @Column(name = "code", nullable = false, columnDefinition = "CHAR(36)")
     private String code;
 
-    @Column(name = "receiver_code", nullable = false, length = 36)
+    @Column(name = "receiver_code", nullable = false, columnDefinition = "CHAR(36)")
     private String receiverCode;
 
-    @Column(name = "contract_code", nullable = false, length = 36)
+    @Column(name = "contract_code", nullable = false, columnDefinition = "CHAR(36)")
     private String contractCode;
 
     @Column(name = "amount", nullable = false)
     private Long amount;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
-    private String status;
+    private SettlementStatus status;
 
     @Column(name = "progressing_at", nullable = false)
     private Instant progressingAt;

--- a/contract-service/src/main/java/com/example/contractservice/settlement/entity/SettlementEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/entity/SettlementEntity.java
@@ -1,0 +1,48 @@
+package com.example.contractservice.settlement.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "settlements")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SettlementEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, length = 36)
+    private String code;
+
+    @Column(name = "receiver_code", nullable = false, length = 36)
+    private String receiverCode;
+
+    @Column(name = "contract_code", nullable = false, length = 36)
+    private String contractCode;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @Column(name = "status", nullable = false)
+    private String status;
+
+    @Column(name = "progressing_at", nullable = false)
+    private Instant progressingAt;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "processed_at")
+    private Instant processedAt;
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/settlement/entity/SettlementEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/entity/SettlementEntity.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -33,8 +34,11 @@ public class SettlementEntity {
     @Column(name = "contract_code", nullable = false, columnDefinition = "CHAR(36)")
     private String contractCode;
 
-    @Column(name = "amount", nullable = false)
-    private Long amount;
+    @Column(name = "original_amount", nullable = false)
+    private Long originalAmount;
+
+    @Column(name = "settled_amount")
+    private Long settledAmount;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
@@ -46,7 +50,10 @@ public class SettlementEntity {
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
-    @Column(name = "processed_at")
-    private Instant processedAt;
+    @Column(name = "settled_at")
+    private Instant settledAt;
+
+    @Column(name = "settlement_rate", precision = 5, scale = 2)
+    private BigDecimal settlementRate;
 
 }

--- a/contract-service/src/main/java/com/example/contractservice/settlement/repository/SettlementJpaRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/repository/SettlementJpaRepository.java
@@ -1,0 +1,8 @@
+package com.example.contractservice.settlement.repository;
+
+import com.example.contractservice.settlement.entity.SettlementEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SettlementJpaRepository extends JpaRepository<SettlementEntity, Long> {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/settlement/repository/SettlementRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/repository/SettlementRepository.java
@@ -1,0 +1,11 @@
+package com.example.contractservice.settlement.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SettlementRepository {
+    private SettlementJpaRepository settlementJpaRepository;
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/settlement/service/SettlementScheduledService.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/service/SettlementScheduledService.java
@@ -1,0 +1,12 @@
+package com.example.contractservice.settlement.service;
+
+import com.example.contractservice.settlement.repository.SettlementRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementScheduledService {
+    private SettlementRepository settlementRepository;
+
+}


### PR DESCRIPTION
## 📌 목적
- 계약, 정산, 예치금 도메인/엔티티를 생성하여 기본 틀을 구축합니다.
- Swagger API 명세를 작성하여 API 정보를 알 수 있습니다.

## ✅ 변경 사항
### 1. 의존성 추가
대표적으로 다음 의존성을 추가했습니다.
* Lombok
* Spring Kafka
* Spring Batch
* Spring Data JPA
* OpenApi 2.8.5(Swagger)
* Prometheus
* QueryDSL
* Spring Validation
### 2. Contract(계약), Deposit(예치금), Settlement(정산) 엔티티/도메인 생성
ERD 다이어그램에 나타난 테이블 컬럼에 맞춰 엔티티를 생성했으며 그에 맞게 도메인도 구축했습니다. 기본적으로 UUID가 36자임을 감안해 code는 CHAR(36)으로 생성했습니다.
MVC 패턴에 맞게 컨트롤러, 서비스, 레포지토리도 기본적인 생성만 해두었습니다. 다만 정산은 컨트롤러가 현재 필요가 없기에, 서비스와 레포지토리만 존재합니다.

### 3. Swagger API 명세서 작성
컨트롤러와 DTO에 적절한 어노테이션을 붙여서 자세한 사항을 표시하도록 하였습니다. 허나 현재는 실패에 대한 응답은 없습니다. 이는 개발해 감에 따라 추가될 것으로 예상합니다.
컨트롤러에 Swagger 어노테이션이 많이 붙어있으면 가시성을 저해할 것 같아서 어노테이션을 묶어 최대한 깔끔하도록 처리했습니다. 묶여진 어노테이션은 각 도메인별 `common.swagger.annotation` 패키지에 모아두었습니다.

## 🧪 테스트 방법
모듈을 켜주시고 컨트롤러에 표기된 API로 직접 호출해보시면 됩니다.
현재 Swagger는 따로 gateway를 타지 않고 있는 관계로, Swagger 페이지에 접근하려면 `localhost:{모듈포트}/swagger-ui/index.html`로 접근하시면 됩니다.
<img width="1454" height="710" alt="image" src="https://github.com/user-attachments/assets/3f192541-34b2-41fb-876e-9e29162f9d98" />


## 📎 참고 사항
코드 변경 사항이 1000줄이 넘었습니다... 400줄 내외일 거라 생각했는데 착오였던 것 같습니다. 허나 대부분 단순한 기능이며, 새로운 클래스 파일로 인한 import 문이거나 DTO, 스웨거 설정용 코드일 것입니다. 그래서 다음을 중점적으로 확인해주시면 좀 더 편한 코드 리뷰가 가능하실 것 같습니다.
* 각 도메인 별 `domain` 내 클래스와 VO들
* 각 도메인 별 `entity` 내 클래스(엔티티)
* Swagger에 직접 접속하여 요청/응답 형식 괜찮은지 확인

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [x] 코드 컨벤션을 모두 지켰나요?
- [x] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
