### PR TITLE
feat(chat): 실시간 채팅 환경 초기 설정

### DIFF
--- a/communication-service/build.gradle
+++ b/communication-service/build.gradle
@@ -25,6 +25,9 @@ ext {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/communication-service/src/main/java/com/example/communicationservice/config/WebSocketConfiguration.java
+++ b/communication-service/src/main/java/com/example/communicationservice/config/WebSocketConfiguration.java
@@ -19,7 +19,6 @@ public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/chat") // STOMP 클라이언트가 최초로 WebSocket handshake를 요청하는 URL
-            .setAllowedOrigins("http://localhost:8080", "http://localhost:3000") // CORS 허용
             .withSockJS();
     }
 

--- a/communication-service/src/main/java/com/example/communicationservice/config/WebSocketConfiguration.java
+++ b/communication-service/src/main/java/com/example/communicationservice/config/WebSocketConfiguration.java
@@ -1,0 +1,26 @@
+package com.example.communicationservice.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/queue"); // 메시지 브로커의 구독 prefix
+        registry.setApplicationDestinationPrefixes("/app"); // @MessageMapping이 붙은 컨트롤러로 라우팅할 prefix
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/chat") // STOMP 클라이언트가 최초로 WebSocket handshake를 요청하는 URL
+            .setAllowedOrigins("http://localhost:8080", "http://localhost:3000") // CORS 허용
+            .withSockJS();
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/config/WebSocketConfiguration.java
+++ b/communication-service/src/main/java/com/example/communicationservice/config/WebSocketConfiguration.java
@@ -2,6 +2,7 @@ package com.example.communicationservice.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -12,6 +13,7 @@ public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer 
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.setPathMatcher(new AntPathMatcher("."));
         registry.enableSimpleBroker("/queue"); // 메시지 브로커의 구독 prefix
         registry.setApplicationDestinationPrefixes("/app"); // @MessageMapping이 붙은 컨트롤러로 라우팅할 prefix
     }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/ChatMessageController.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/ChatMessageController.java
@@ -12,7 +12,7 @@ public class ChatMessageController {
 
     private final SimpMessagingTemplate messagingTemplate;
 
-    @MessageMapping("/chat.send")
+    @MessageMapping("chat.send")
     public void handleChatMessage(ChatMessageSendRequest request) {
         String destinationPrefix = "/queue/room/";
         messagingTemplate.convertAndSend(destinationPrefix + request.roomId(), request);

--- a/communication-service/src/main/java/com/example/communicationservice/controller/ChatMessageController.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/ChatMessageController.java
@@ -1,0 +1,21 @@
+package com.example.communicationservice.controller;
+
+import com.example.communicationservice.controller.dto.request.ChatMessageSendRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatMessageController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/chat.send")
+    public void handleChatMessage(ChatMessageSendRequest request) {
+        String destinationPrefix = "/queue/room/";
+        messagingTemplate.convertAndSend(destinationPrefix + request.roomId(), request);
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatMessageSendRequest.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatMessageSendRequest.java
@@ -1,0 +1,8 @@
+package com.example.communicationservice.controller.dto.request;
+
+public record ChatMessageSendRequest(
+    String roomId,
+    String senderId,
+    String content
+) {
+}

--- a/communication-service/src/main/resources/static/chat-test.html
+++ b/communication-service/src/main/resources/static/chat-test.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Chat Room Test</title>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1.6.1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+    <style>
+        #messages { border:1px solid #ccc; padding:10px; height:300px; overflow:auto; margin-bottom:10px; }
+        #roomId { width:50px; }
+        #senderId { width:80px; }
+        #messageInput { width:200px; }
+    </style>
+</head>
+<body>
+<h2>Chat Room Test</h2>
+<label>Room ID: <input type="text" id="roomId" value="950"/></label><br><br>
+<label>Sender ID: <input type="text" id="senderId" value="userA"/></label><br><br>
+<div id="messages"></div>
+<input type="text" id="messageInput" placeholder="Type a message" />
+<button id="sendBtn">Send</button>
+
+<script>
+    let stompClient = null;
+    let currentSubscription = null;
+    const messagesDiv = document.getElementById('messages');
+    const roomInput = document.getElementById('roomId');
+    const senderInput = document.getElementById('senderId');
+
+    function appendMessage(text) {
+        const p = document.createElement('p');
+        p.textContent = text;
+        messagesDiv.appendChild(p);
+        messagesDiv.scrollTop = messagesDiv.scrollHeight;
+    }
+
+    // 1. 구독 처리 로직
+    function subscribeToRoom(roomId) {
+        if (currentSubscription) {
+            currentSubscription.unsubscribe();
+            appendMessage('Unsubscribed from previous room.');
+        }
+
+        currentSubscription = stompClient.subscribe('/queue/room/' + roomId, function(stompMessage) {
+            try {
+                const receivedMsg = JSON.parse(stompMessage.body);
+                const currentSenderId = senderInput.value;
+                let displayPrefix;
+
+                if (receivedMsg.senderId === currentSenderId) {
+                    displayPrefix = 'Me: ';
+                } else {
+                    displayPrefix = receivedMsg.senderId + ': ';
+                }
+
+                appendMessage(displayPrefix + receivedMsg.content);
+
+            } catch(e) {
+                console.error('[DEBUG] Error parsing message:', e);
+                appendMessage('Error parsing message: ' + e);
+            }
+        });
+
+        appendMessage('**Subscribed to room: ' + roomId + '**');
+    }
+
+    // 2. 연결 로직
+    function connect() {
+        appendMessage('Connecting...');
+
+        const socket = new SockJS('http://localhost:8080/chat');
+        stompClient = Stomp.over(socket);
+
+        stompClient.connect({}, function(frame) {
+            appendMessage('Connected: ' + frame);
+
+            const initialRoomId = roomInput.value;
+            subscribeToRoom(initialRoomId);
+
+        }, function(error) {
+            appendMessage('Error: ' + error);
+        });
+    }
+
+    // 3. 메시지 전송
+    document.getElementById('sendBtn').addEventListener('click', () => {
+        const msg = document.getElementById('messageInput').value;
+        const roomId = roomInput.value;
+        const senderId = senderInput.value;
+
+        if(stompClient && stompClient.connected && msg.trim() !== '') {
+            const payload = {
+                roomId: roomId,
+                senderId: senderId,
+                content: msg
+            };
+
+            stompClient.send('/app/chat.send', {}, JSON.stringify(payload));
+            document.getElementById('messageInput').value = '';
+        } else {
+            appendMessage('Error: Not connected or message is empty.');
+        }
+    });
+
+    // 4. Enter 키로 전송
+    document.getElementById('messageInput').addEventListener('keypress', function(e) {
+        if (e.key === 'Enter') {
+            document.getElementById('sendBtn').click();
+        }
+    });
+
+    // 5. roomId 변경 시 재구독
+    roomInput.addEventListener('change', () => {
+        const newRoomId = roomInput.value;
+
+        if (stompClient && stompClient.connected) {
+            appendMessage('Room changed, re-subscribing...');
+            subscribeToRoom(newRoomId);
+        } else {
+            appendMessage('STOMP client not connected. Attempting reconnect...');
+            connect();
+        }
+    });
+
+    // 6. 페이지 로드 시 자동 연결
+    console.log('[DEBUG] Setting up load event');
+    window.addEventListener('load', function() {
+        connect();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📌 목적
- 채팅 기능 구현을 위한 기본 설정을 완료합니다.
- 간단한 1:1 채팅 송수신 동작을 확인합니다.

## ✅ 변경 사항
- websocket, lombok 의존성을 추가했습니다.
- STOMP 기반 1:1 채팅을 위한 브로커를 설정하고 메시지 송수신 로직을 구현했습니다.
    - 내장 메시지 브로커를 이용해 송신자의 메시지를 수신자에게 전달합니다.
    - 클라이언트는 `/app/chat.send`로 메시지를 전송하며, 이때 접두사인 `/app`은 설정 파일에서 정의되므로 컨트롤러의 `@MessageMapping`에서는 생략합니다. 
    - 메시지 브로커는 컨트롤러에서 받은 메시지를 구독 중인 사용자에게 전달하며, 이때 대상 경로는 `/queue/room/{room-id}`입니다. 
  ```java
      // ChatMessageController.java
      @MessageMapping("chat.send")
      public void handleChatMessage(ChatMessageSendRequest request) {
          String destinationPrefix = "/queue/room/";
          messagingTemplate.convertAndSend(destinationPrefix + request.roomId(), request);
      }
  ```

## 🧪 테스트 방법
- `communication-service`를 실행합니다.
- 크롬 탭을 두 개 열고 `http://localhost:8080/chat-test.html`에 각각 접속합니다.
- 각 탭을 다른 사용자로 시뮬레이션하기 위해 한쪽 탭의 `Sender ID`를 변경합니다. (`Room ID`는 모두 일치해야 합니다.)
- 메시지를 전송합니다.

## 📎 참고 사항
https://github.com/user-attachments/assets/4b8824bc-bad9-4345-8833-89469382e1f6

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [x] 코드 컨벤션을 모두 지켰나요?
- [x] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
