### PR TITLE
feat(gateway): Api GateWay 인증 필터 구현 및 적용

### DIFF
--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -30,6 +30,11 @@ dependencies {
     //gateway-service
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
 
+    //jwt 관련 의존성
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+    
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -34,7 +34,11 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
-    
+
+    //lombok
+    implementation 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/gateway-service/src/main/java/com/example/gatewayservice/common/exception/BusinessException.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/common/exception/BusinessException.java
@@ -1,0 +1,13 @@
+package com.example.gatewayservice.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/common/exception/ErrorCode.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/common/exception/ErrorCode.java
@@ -1,0 +1,23 @@
+package com.example.gatewayservice.common.exception;
+
+public enum ErrorCode {
+
+    //401
+    UNAUTHORIZATION("인증되지 않은 요청입니다.", 401);
+
+    private final String message;
+    private final int statusCode;
+
+    ErrorCode(String message, int statusCode) {
+        this.message = message;
+        this.statusCode = statusCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/common/exception/ErrorCode.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/common/exception/ErrorCode.java
@@ -1,23 +1,23 @@
 package com.example.gatewayservice.common.exception;
 
+import lombok.Getter;
+
+@Getter
 public enum ErrorCode {
 
     //401
-    UNAUTHORIZATION("인증되지 않은 요청입니다.", 401);
-
-    private final String message;
+    UNAUTHORIZATION(401, "UN_AUTHORIZATION","인증되지 않은 요청입니다."),
+    NEED_RE_LOGIN(401,"NEED_RE_LOGIN", "로그인을 다시 해주세요."),
+    NEED_RE_ISSUE(401, "NEED_RE_ISSUE", "AccessToken을 재발행해주세요."),
+    NEED_SIGNUP(403, "NEED_SIGNUP", "회원가입이 필요합니다.");
     private final int statusCode;
+    private final String code;
+    private final String message;
 
-    ErrorCode(String message, int statusCode) {
+    ErrorCode(int statusCode, String code, String message) {
         this.message = message;
+        this.code = code;
         this.statusCode = statusCode;
     }
 
-    public String getMessage() {
-        return message;
-    }
-
-    public int getStatusCode() {
-        return statusCode;
-    }
 }

--- a/gateway-service/src/main/java/com/example/gatewayservice/common/jwt/JwtKeyProvider.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/common/jwt/JwtKeyProvider.java
@@ -1,4 +1,4 @@
-package com.example.gatewayservice.jwt;
+package com.example.gatewayservice.common.jwt;
 
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;

--- a/gateway-service/src/main/java/com/example/gatewayservice/common/jwt/JwtProperties.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/common/jwt/JwtProperties.java
@@ -1,0 +1,17 @@
+package com.example.gatewayservice.common.jwt;
+
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class JwtProperties {
+
+    @Value("${jwt.claims.member-code}")
+    private String memberCodeClaims;
+
+    @Value("${jwt.claims.is-sign}")
+    private String isSignClaims;
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/common/jwt/JwtTokenParser.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/common/jwt/JwtTokenParser.java
@@ -19,4 +19,13 @@ public class JwtTokenParser {
         }
         return memberCode.toString();
     }
+
+    public boolean parseIsSign(Claims claims) {
+        Object isSignObj = claims.get(jwtProperties.getIsSignClaims());
+        if (!(isSignObj instanceof Boolean)) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZATION);
+        }
+
+        return (Boolean) isSignObj;
+    }
 }

--- a/gateway-service/src/main/java/com/example/gatewayservice/common/jwt/JwtTokenParser.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/common/jwt/JwtTokenParser.java
@@ -1,0 +1,22 @@
+package com.example.gatewayservice.common.jwt;
+
+import com.example.gatewayservice.common.exception.BusinessException;
+import com.example.gatewayservice.common.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenParser {
+
+    private final JwtProperties jwtProperties;
+
+    public String parseMemberCode(Claims claims) {
+        Object memberCode = claims.get(jwtProperties.getMemberCodeClaims());
+        if (memberCode == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZATION);
+        }
+        return memberCode.toString();
+    }
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/common/jwt/JwtTokenValidator.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/common/jwt/JwtTokenValidator.java
@@ -1,0 +1,29 @@
+package com.example.gatewayservice.common.jwt;
+
+import com.example.gatewayservice.common.exception.BusinessException;
+import com.example.gatewayservice.common.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenValidator {
+
+    private final JwtKeyProvider jwtKeyProvider;
+
+    //AccessToken의 검증은 Api Gateway에서 일어나기 떄문에 Member 모듈에서는 AccessToken 검증은 생략
+    public Claims validateAccessToken(String token) {
+        try {
+            return Jwts.parser()
+                .verifyWith(jwtKeyProvider.getAccessTokenSignKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        } catch (JwtException e) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZATION);
+        }
+    }
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/common/web/model/dto/ResponseDto.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/common/web/model/dto/ResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.gatewayservice.common.web.model.dto;
+
+public record ResponseDto<T>(
+
+    int code,
+
+    String message,
+
+    T data
+) {
+
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/filter/CorsGlobalFilter.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/filter/CorsGlobalFilter.java
@@ -1,5 +1,7 @@
 package com.example.gatewayservice.filter;
 
+import jakarta.annotation.PostConstruct;
+import java.util.Arrays;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
@@ -17,7 +19,15 @@ import reactor.core.publisher.Mono;
 public class CorsGlobalFilter implements GlobalFilter {
 
     @Value("${cors.allowed.origin}")
-    private List<String> allowedOrigin;
+    private String allowedOrigin;
+
+    private List<String> allowedOriginList;
+
+
+    @PostConstruct
+    public void init() {
+        allowedOriginList = Arrays.asList(allowedOrigin.split(","));
+    }
 
 
     @Override
@@ -26,7 +36,7 @@ public class CorsGlobalFilter implements GlobalFilter {
         HttpHeaders headers = response.getHeaders();
 
         String requestOrigin = exchange.getRequest().getHeaders().getOrigin();
-        if (requestOrigin != null && allowedOrigin.contains(requestOrigin)) {
+        if (requestOrigin != null && allowedOriginList.contains(requestOrigin)) {
             headers.add("Access-Control-Allow-Origin", requestOrigin);
         }
 

--- a/gateway-service/src/main/java/com/example/gatewayservice/filter/CorsGlobalFilter.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/filter/CorsGlobalFilter.java
@@ -1,0 +1,47 @@
+package com.example.gatewayservice.filter;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Order(-1)
+@Component
+public class CorsGlobalFilter implements GlobalFilter {
+
+    @Value("${cors.allowed.origin}")
+    private List<String> allowedOrigin;
+
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        ServerHttpResponse response = exchange.getResponse();
+        HttpHeaders headers = response.getHeaders();
+
+        String requestOrigin = exchange.getRequest().getHeaders().getOrigin();
+        if (requestOrigin != null && allowedOrigin.contains(requestOrigin)) {
+            headers.add("Access-Control-Allow-Origin", requestOrigin);
+        }
+
+        headers.add("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
+        headers.add("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization");
+        headers.add("Access-Control-Allow-Credentials", "true");
+        headers.add("Access-Control-Max-Age", "3600");
+
+        // Preflight 요청 처리
+        if (exchange.getRequest().getMethod() == HttpMethod.OPTIONS) {
+            response.setStatusCode(org.springframework.http.HttpStatus.OK);
+            return response.setComplete();
+        }
+
+        return chain.filter(exchange);
+    }
+
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/filter/GlobalExceptionHandlingFilter.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/filter/GlobalExceptionHandlingFilter.java
@@ -1,0 +1,66 @@
+package com.example.gatewayservice.filter;
+
+
+import com.example.gatewayservice.common.exception.BusinessException;
+import com.example.gatewayservice.common.exception.ErrorCode;
+import com.example.gatewayservice.common.web.model.dto.ResponseDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@Component
+public class GlobalExceptionHandlingFilter
+    extends AbstractGatewayFilterFactory<GlobalExceptionHandlingFilter.Config> {
+
+    private final ObjectMapper om;
+
+    public GlobalExceptionHandlingFilter(ObjectMapper om) {
+        super(Config.class);
+        this.om = om;
+    }
+
+    public static class Config {
+
+    }
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return (exchange, chain) -> chain.filter(exchange)
+            .onErrorResume(BusinessException.class, ex -> {
+                ErrorCode errorCode = ex.getErrorCode();
+                return writeErrorResponse(exchange.getResponse(), errorCode);
+            });
+    }
+
+    private Mono<Void> writeErrorResponse(ServerHttpResponse response, ErrorCode errorCode) {
+        response.setStatusCode(HttpStatus.valueOf(errorCode.getStatusCode()));
+        response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+        ResponseDto<Map<String, String>> body = new ResponseDto<>(
+            errorCode.getStatusCode(),
+            errorCode.getMessage(),
+            Map.of("errorCode", errorCode.getCode())
+        );
+
+        byte[] bytes;
+        try {
+            bytes = om.writeValueAsBytes(body);
+        } catch (JsonProcessingException e) {
+            bytes = ("{\"code\":" + errorCode.getStatusCode() +
+                ",\"message\":\"" + errorCode.getMessage() +
+                "\",\"data\":{\"errorCode\":\"" + errorCode.getCode() + "\"}}")
+                .getBytes(StandardCharsets.UTF_8);
+        }
+
+        return response.writeWith(Mono.just(response.bufferFactory().wrap(bytes)));
+    }
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/filter/IsSignCheckFilter.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/filter/IsSignCheckFilter.java
@@ -1,0 +1,45 @@
+package com.example.gatewayservice.filter;
+
+import com.example.gatewayservice.common.exception.BusinessException;
+import com.example.gatewayservice.common.exception.ErrorCode;
+import com.example.gatewayservice.common.jwt.JwtTokenParser;
+import com.example.gatewayservice.filter.IsSignCheckFilter.Config;
+import io.jsonwebtoken.Claims;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IsSignCheckFilter extends AbstractGatewayFilterFactory<Config> {
+
+    private final JwtTokenParser jwtTokenParser;
+
+    public IsSignCheckFilter(JwtTokenParser jwtTokenParser) {
+        super(Config.class);
+        this.jwtTokenParser = jwtTokenParser;
+    }
+
+    public static class Config {
+
+    }
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return (exchange, chain) -> {
+            Claims claims = (Claims) exchange.getAttribute("claims");
+
+            if (claims == null) {
+                throw new BusinessException(ErrorCode.NEED_SIGNUP);
+            }
+
+            Boolean isSign = jwtTokenParser.parseIsSign(claims);
+            if (!Boolean.TRUE.equals(isSign)) {
+                throw new BusinessException(ErrorCode.NEED_SIGNUP);
+            }
+
+            return chain.filter(exchange);
+        };
+    }
+
+
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/filter/IsSignCheckFilter.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/filter/IsSignCheckFilter.java
@@ -29,7 +29,7 @@ public class IsSignCheckFilter extends AbstractGatewayFilterFactory<Config> {
             Claims claims = (Claims) exchange.getAttribute("claims");
 
             if (claims == null) {
-                throw new BusinessException(ErrorCode.NEED_SIGNUP);
+                throw new BusinessException(ErrorCode.UNAUTHORIZATION);
             }
 
             Boolean isSign = jwtTokenParser.parseIsSign(claims);

--- a/gateway-service/src/main/java/com/example/gatewayservice/filter/TokenAuthenticationFilter.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/filter/TokenAuthenticationFilter.java
@@ -1,0 +1,93 @@
+package com.example.gatewayservice.filter;
+
+import com.example.gatewayservice.common.exception.BusinessException;
+import com.example.gatewayservice.common.exception.ErrorCode;
+import com.example.gatewayservice.common.jwt.JwtTokenParser;
+import com.example.gatewayservice.common.jwt.JwtTokenValidator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class TokenAuthenticationFilter extends AbstractGatewayFilterFactory<TokenAuthenticationFilter.Config> {
+
+
+    public static class Config {
+
+    }
+
+    private final JwtTokenValidator jwtTokenValidator;
+
+    private final JwtTokenParser jwtTokenParser;
+
+    public TokenAuthenticationFilter(ObjectMapper om, JwtTokenValidator jwtTokenValidator,
+        JwtTokenParser jwtTokenParser) {
+        super(Config.class);
+        this.jwtTokenValidator = jwtTokenValidator;
+        this.jwtTokenParser = jwtTokenParser;
+    }
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return (exchange, chain) -> {
+            ServerHttpRequest request = exchange.getRequest();
+
+            // Request에서 토큰 및 헤더가 있는 지 확인
+            if (!request.getHeaders().containsKey(HttpHeaders.AUTHORIZATION)) {
+                log.info("AccessToken이 비어있습니다. RefreshToken을 확인합니다.");
+
+                if (!request.getCookies().containsKey("refresh-token")) {
+                    log.error("사용자 인증 정보가 없습니다. 재로그인을 진행해주세요");
+
+                    //재로그인을 하라는 응답을 보내고 싶음
+                    throw new BusinessException(ErrorCode.NEED_RE_LOGIN);
+                } else {
+                    log.info("RefreshToken을 통해 AccessToken 재요청 로직을 수행하세요.");
+
+                    // AccessToken 재발급 하라는 응답을 보내고 싶음.
+                    throw new BusinessException(ErrorCode.NEED_RE_ISSUE);
+                }
+            }
+
+            String accessToken = resolveToken(request).orElseThrow(
+                () -> new BusinessException(ErrorCode.NEED_RE_ISSUE));
+
+            Claims claims = jwtTokenValidator.validateAccessToken(accessToken);
+
+            String memberCode = jwtTokenParser.parseMemberCode(claims);
+
+            ServerHttpRequest mutatedRequest = request.mutate()
+                .header("X-CODE", memberCode)
+                .build();
+
+            //다음 IsSignCheckFilter에서 확인할 수도 있으니 claims를 넘겨줌
+            exchange.getAttributes().put("claims", claims);
+
+            return chain.filter(exchange.mutate().request(mutatedRequest).build());
+        };
+    }
+
+    private Optional<String> resolveToken(ServerHttpRequest request) {
+
+        String bearerToken = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return Optional.of(bearerToken.substring(7));
+        }
+
+        HttpCookie tokenCookie = request.getCookies().getFirst("token");
+        if (tokenCookie != null) {
+            return Optional.of(tokenCookie.getValue());
+        }
+
+        return Optional.empty();
+    }
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/jwt/JwtKeyProvider.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/jwt/JwtKeyProvider.java
@@ -1,0 +1,23 @@
+package com.example.gatewayservice.jwt;
+
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtKeyProvider {
+
+    @Value("${jwt.access-token.secret}")
+    private String accessTokenSecret;
+
+    public SecretKey getAccessTokenSignKey() {
+        return getSigningKey(accessTokenSecret);
+    }
+
+    private SecretKey getSigningKey(String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+}


### PR DESCRIPTION
## 📌 목적
- 인증이 필요한 요청에 대하여 Api Gate Way에서 요청을 필터링 할 수 있도록
각종 filter 들을 구현하였습니다

## ✅ 변경 사항
구현한 필터는 크게
- GlobalExceptionHandlingFilter
- isSignCheckFilter
- TokenAuthenticationFilter
- CorsGlobalFilter이며 

**TokenAuthentiactionFilter에서 쓰이는 Jwt Token 과 관련한 Class 들을 구현**했습니다.

**Member 모듈에서는 AccessToken 검증 로직이 필요하지 않아서 뺏던 것**처럼

**GateWay 모듈에서는 RefreshToken 검증이나 Token 생성 로직 없이 구현**을 하였습니다.

**gateway의 RefreshToken의 검증을 제외**한 것은 
gateway는 인증 모듈로 설정을 했고, 
RefreshToken은 인증과는 직접적 연관이 없는 데이터이기 때문에 
**검증을 하지 않는게 맞지 않을까라고 생각**하여 해당 RefreshToken의 검증은 Member 모듈에서 하는 것으로 한정했습니다.

해당 생각은 제 개인적 의견이니 리뷰를 하시다가 **gateway에서 해야할 것 같다! 하시면 편하게 말씀해주세요!** 
강사님에게 질문을 하거나 팀끼리 논의를 해서 코드를 수정해도 됩니다!

아마 필터 자체는 그렇게 복잡한 로직이 들어가지 않아서 

GlobalExceptionHandlingFilter와 isSignCheckFilter 관련한 설명만 조금 하겠습니다!

### GlobalExceptionHandlingFilter

저희가 MVC 에서 흔히 쓰는 **GlogbalExceptionHandler의 Filter 버전**입니다.
다만 **GlobalExceptionHandler의 경우 @ContollerAdviece를 써서 예외를 처리하는 데**

**@ControllerAdivce는 컨트롤러가 예외가 발생한 시점에 호출되어 로직이 처리  되지만** 

해당 필터를 적용시킨 모든 요청에 대해 성공하든 실패하든 거치게 된다는 차이가 있을 것 같습니다.

### IsSignCheckFilter

멤버 모듈을 제외하고는 사실상 **TokenAuthentiactionFilter와 함께 쓰이는 필터**입니다.
저희가 소셜로그인을 기능으로 로그인을 구현해서 로그인과 회원가입이 따로 분리가 되었고, 
그로인해 Social Member Entity는 있는데 Member는 없는 유저들이 존재합니다.

Member가 없는 경우 실질적으로 채팅, 게시글 작성과 같은 기능을 사용하지 못해야하기 때문에 
여러 인증이 필요한 요청에 대해 회원가입을 진행했는 지 확인해주어야합니다. 

각 모듈에서 MemberCode의 Member가 실제로 있는 지 확인하는 것은 불필요한 코드 중복을 주는 것 같아서
api gateway에서 처리해주면 좋겠다고 생각했고,

api-gateway에서 회원가입을 했는 지 확인하기 위해 매번 멤버 모듈을 거치는 것은 api gateway의 부하를 키우는 것 같아

이것과 관련하여 **AccessToken에 isSign Claims를 추가**했습니다.
해당 Claims는 **AccessToken을 발행**할 때 **SocialMember만 있으면 false**, 
**SocialMember와 Member 둘 다 있다면 true**를 할당해줍니다.

**IsSignCheckFilter**는 AccessToken의 해당 isSign값을 확인해주는 필터입니다.



## 🧪 테스트 방법
- 필터에 경우에도 실제 요청이 들어와야 테스트를 할 수 있어서 별도의 테스트 코드 작성의 감이 잡히지 않아
실제 실행 화면을 공유하였습니다.

/api/members/healthCheck 에 필터를 적용시켰으며 실제 AccessToken 이 X-Code로 잘 변환되는지를 보기위해
```
    @GetMapping("/healthCheck")
    public String healthCheck(@RequestHeader(name = "X-CODE", required = false) String memberCode) {
        if(memberCode==null){
            memberCode=" Internal API ";
        }
        
        return "Member"+memberCode+" OK";
    }
```

해당 구현에 대해 4가지 상황을 Test 한 결과사진을 공유하겠습니다.

1. AccessToken 과 RefreshToken 모두 없는 경우
2. AccessToken이 잘못되었는데 RefreshToken(앞서 설명드렸다 싶이 진짜 있는지만 확인합니다!)이 있는 경우
3. IsSignCheckFilter를 할당하고 AccessToken이 유효하지만 isSign이 false 인 경우
4. IsSignCheckFilter를 해제하고 AccessToken이 유효한 경우

#### [AccessToken 과 RefreshToken 모두 없는 경우]
<img width="1743" height="759" alt="image" src="https://github.com/user-attachments/assets/95afce47-763f-4bf7-86c3-875f975623d1" />


#### [AccessToken이 잘못되었는데 RefreshToken이 있는 경우]
<img width="2079" height="866" alt="image" src="https://github.com/user-attachments/assets/f701e596-4d92-47a5-9644-30fe4dd11cfe" />

#### [IsSignCheckFilter를 할당하고 AccessToken이 유효하지만 isSign이 false 인 경우]
<img width="1714" height="800" alt="image" src="https://github.com/user-attachments/assets/dc8846eb-f15e-4cdd-976b-68954201d679" />


#### [IsSignCheckFilter를 해제하고 AccessToken이 유효한 경우]
<img width="2162" height="790" alt="image" src="https://github.com/user-attachments/assets/9abeccc2-a204-4493-b6dc-5017338dae79" />


## 📎 참고 사항
#### 현재 저의 응답 형식이 구버전입니다! 제가 Develop에 Merge 되기전에 여러 모듈들을 작업해버려서 이후에 한번에 통합하여 작업할 것 같습니다!

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [ ] 코드 컨벤션을 모두 지켰나요?
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
