### PR TITLE
feat(search): 의뢰글 검색 기능 개발

### DIFF
--- a/search-service/src/main/java/com/example/searchservice/commission/common/PaymentType.java
+++ b/search-service/src/main/java/com/example/searchservice/commission/common/PaymentType.java
@@ -2,5 +2,5 @@ package com.example.searchservice.commission.common;
 
 public enum PaymentType {
     MONTHLY,
-    ONE_TIME
+    PER_JOB
 }

--- a/search-service/src/main/java/com/example/searchservice/commission/controller/CommissionSearchController.java
+++ b/search-service/src/main/java/com/example/searchservice/commission/controller/CommissionSearchController.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,8 +26,17 @@ public class CommissionSearchController implements CommissionSearchControllerSwa
     private final CommissionService commissionService;
 
     @GetMapping
-    public BaseResponse<Page<CommissionResponseDto>> search(String query, SearchScope scope, List<String> tags, PaymentType paymentType,
-            Long minPay, LocalDate startedAt, LocalDate endedAt, int page, int size) {
+    public BaseResponse<Page<CommissionResponseDto>> search(
+            @RequestParam(required = false) String query,
+            @RequestParam(defaultValue = "all") SearchScope scope,
+            @RequestParam(required = false) List<String> tags,
+            @RequestParam(name = "payment-type", required = false) PaymentType paymentType,
+            @RequestParam(name = "min-pay", required = false) Long minPay,
+            @RequestParam(name = "started-at", required = false) LocalDate startedAt,
+            @RequestParam(name = "ended-at", required = false) LocalDate endedAt,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
 
         Page<CommissionResponseDto> result;
 

--- a/search-service/src/main/java/com/example/searchservice/commission/controller/CommissionSearchController.java
+++ b/search-service/src/main/java/com/example/searchservice/commission/controller/CommissionSearchController.java
@@ -1,10 +1,15 @@
 package com.example.searchservice.commission.controller;
 
 import com.example.searchservice.commission.common.PaymentType;
+import com.example.searchservice.commission.dto.CommissionResponseDto;
+import com.example.searchservice.commission.service.CommissionService;
+import com.example.searchservice.common.response.BaseResponse;
 import com.example.searchservice.common.vo.SearchScope;
 import com.example.searchservice.commission.controller.swagger.CommissionSearchControllerSwagger;
 import java.time.LocalDate;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,18 +19,25 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/search/commissions")
+@RequiredArgsConstructor
 public class CommissionSearchController implements CommissionSearchControllerSwagger {
 
+    private final CommissionService commissionService;
+
     @GetMapping
-    @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<Object> search(String query, SearchScope scope, List<String> tags, PaymentType paymentType,
+    public BaseResponse<Page<CommissionResponseDto>> search(String query, SearchScope scope, List<String> tags, PaymentType paymentType,
             Long minPay, LocalDate startedAt, LocalDate endedAt, int page, int size) {
-        return null;
+
+        Page<CommissionResponseDto> result;
+
+        result = commissionService.search(query, scope, page, size);
+
+        return BaseResponse.ok(result);
     }
 
     @GetMapping("/suggest")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<Object> suggest(String query, int size) {
+    public BaseResponse<CommissionResponseDto> suggest(String query, int size) {
         return null;
     }
 }

--- a/search-service/src/main/java/com/example/searchservice/commission/controller/CommissionSearchController.java
+++ b/search-service/src/main/java/com/example/searchservice/commission/controller/CommissionSearchController.java
@@ -18,14 +18,14 @@ public class CommissionSearchController implements CommissionSearchControllerSwa
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<Object> search(String q, SearchScope scope, List<String> tags, PaymentType paymentType,
+    public ResponseEntity<Object> search(String query, SearchScope scope, List<String> tags, PaymentType paymentType,
             Long minPay, LocalDate startedAt, LocalDate endedAt, int page, int size) {
         return null;
     }
 
     @GetMapping("/suggest")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<Object> suggest(String q, int size) {
+    public ResponseEntity<Object> suggest(String query, int size) {
         return null;
     }
 }

--- a/search-service/src/main/java/com/example/searchservice/commission/controller/swagger/CommissionSearchControllerSwagger.java
+++ b/search-service/src/main/java/com/example/searchservice/commission/controller/swagger/CommissionSearchControllerSwagger.java
@@ -17,11 +17,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Commission Search API", description = "의뢰글 검색 / 검색 키워드 추천 API")
-@OpenAPIDefinition(
-        servers = {
-                @Server(url = "http://localhost:8000", description = "Gateway URL")
-        }
-)
 public interface CommissionSearchControllerSwagger {
 
     @Operation(summary = "의뢰글 검색", description = "조건(검색어, 태그, 급여, 기간 등)을 기반으로 의뢰글을 검색합니다.")

--- a/search-service/src/main/java/com/example/searchservice/commission/controller/swagger/CommissionSearchControllerSwagger.java
+++ b/search-service/src/main/java/com/example/searchservice/commission/controller/swagger/CommissionSearchControllerSwagger.java
@@ -16,7 +16,7 @@ public interface CommissionSearchControllerSwagger {
 
     @Operation(summary = "의뢰글 검색", description = "조건(검색어, 태그, 급여, 기간 등)을 기반으로 의뢰글을 검색합니다.")
     @Parameters({
-            @Parameter(name = "q", description = "검색어", required = false),
+            @Parameter(name = "query", description = "검색어", required = false),
             @Parameter(name = "scope", description = "검색 범위 (all(default) | title | content)"),
             @Parameter(name = "tags", description = "태그 목록", required = false),
             @Parameter(name = "payment-type", description = "급여 지급 방식 (MONTHLY | ONE_TIME)", required = false),
@@ -27,7 +27,7 @@ public interface CommissionSearchControllerSwagger {
             @Parameter(name = "size", description = "페이지 크기", required = false)
     })
     ResponseEntity<Object> search(
-            @RequestParam(required = false) String q,
+            @RequestParam(required = false) String query,
             @RequestParam(defaultValue = "all") SearchScope scope,
             @RequestParam(required = false) List<String> tags,
             @RequestParam(name = "payment-type", required = false) PaymentType paymentType,
@@ -40,11 +40,11 @@ public interface CommissionSearchControllerSwagger {
 
     @Operation(summary = "의뢰글 추천 검색 키워드", description = "입력한 접두어(prefix)를 기반으로 추천 검색 키워드를 반환합니다.")
     @Parameters({
-            @Parameter(name = "q", description = "검색어 접두어", required = true),
+            @Parameter(name = "query", description = "검색어 접두어", required = true),
             @Parameter(name = "size", description = "보여줄 추천 검색 키워드 개수", required = false)
     })
     ResponseEntity<Object> suggest(
-            @RequestParam String q,
+            @RequestParam String query,
             @RequestParam(defaultValue = "10") int size
     );
 }

--- a/search-service/src/main/java/com/example/searchservice/commission/controller/swagger/CommissionSearchControllerSwagger.java
+++ b/search-service/src/main/java/com/example/searchservice/commission/controller/swagger/CommissionSearchControllerSwagger.java
@@ -4,9 +4,11 @@ import com.example.searchservice.commission.common.PaymentType;
 import com.example.searchservice.commission.dto.CommissionResponseDto;
 import com.example.searchservice.common.response.BaseResponse;
 import com.example.searchservice.common.vo.SearchScope;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.util.List;
@@ -15,6 +17,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Commission Search API", description = "의뢰글 검색 / 검색 키워드 추천 API")
+@OpenAPIDefinition(
+        servers = {
+                @Server(url = "http://localhost:8000", description = "Gateway URL")
+        }
+)
 public interface CommissionSearchControllerSwagger {
 
     @Operation(summary = "의뢰글 검색", description = "조건(검색어, 태그, 급여, 기간 등)을 기반으로 의뢰글을 검색합니다.")
@@ -30,15 +37,15 @@ public interface CommissionSearchControllerSwagger {
             @Parameter(name = "size", description = "페이지 크기", required = false)
     })
     BaseResponse<Page<CommissionResponseDto>> search(
-            @RequestParam(required = false) String query,
-            @RequestParam(defaultValue = "all") SearchScope scope,
-            @RequestParam(required = false) List<String> tags,
-            @RequestParam(name = "payment-type", required = false) PaymentType paymentType,
-            @RequestParam(name = "min-pay", required = false) Long minPay,
-            @RequestParam(name = "started-at", required = false) LocalDate startedAt,
-            @RequestParam(name = "ended-at", required = false) LocalDate endedAt,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size
+            String query,
+            SearchScope scope,
+            List<String> tags,
+            PaymentType paymentType,
+            Long minPay,
+            LocalDate startedAt,
+            LocalDate endedAt,
+            int page,
+            int size
     );
 
     @Operation(summary = "의뢰글 추천 검색 키워드", description = "입력한 접두어(prefix)를 기반으로 추천 검색 키워드를 반환합니다.")
@@ -47,7 +54,7 @@ public interface CommissionSearchControllerSwagger {
             @Parameter(name = "size", description = "보여줄 추천 검색 키워드 개수", required = false)
     })
     BaseResponse<CommissionResponseDto> suggest(
-            @RequestParam String query,
-            @RequestParam(defaultValue = "10") int size
+            String query,
+            int size
     );
 }

--- a/search-service/src/main/java/com/example/searchservice/commission/controller/swagger/CommissionSearchControllerSwagger.java
+++ b/search-service/src/main/java/com/example/searchservice/commission/controller/swagger/CommissionSearchControllerSwagger.java
@@ -1,6 +1,8 @@
 package com.example.searchservice.commission.controller.swagger;
 
 import com.example.searchservice.commission.common.PaymentType;
+import com.example.searchservice.commission.dto.CommissionResponseDto;
+import com.example.searchservice.common.response.BaseResponse;
 import com.example.searchservice.common.vo.SearchScope;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -8,6 +10,7 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -26,7 +29,7 @@ public interface CommissionSearchControllerSwagger {
             @Parameter(name = "page", description = "페이지 번호", required = false),
             @Parameter(name = "size", description = "페이지 크기", required = false)
     })
-    ResponseEntity<Object> search(
+    BaseResponse<Page<CommissionResponseDto>> search(
             @RequestParam(required = false) String query,
             @RequestParam(defaultValue = "all") SearchScope scope,
             @RequestParam(required = false) List<String> tags,
@@ -43,7 +46,7 @@ public interface CommissionSearchControllerSwagger {
             @Parameter(name = "query", description = "검색어 접두어", required = true),
             @Parameter(name = "size", description = "보여줄 추천 검색 키워드 개수", required = false)
     })
-    ResponseEntity<Object> suggest(
+    BaseResponse<CommissionResponseDto> suggest(
             @RequestParam String query,
             @RequestParam(defaultValue = "10") int size
     );

--- a/search-service/src/main/java/com/example/searchservice/commission/dto/CommissionResponseDto.java
+++ b/search-service/src/main/java/com/example/searchservice/commission/dto/CommissionResponseDto.java
@@ -17,7 +17,7 @@ public record CommissionResponseDto(
         Long payAmount,
         Boolean isClosed
 ) {
-    public CommissionResponseDto from(CommissionDocumentEntity commissionDocumentEntity) {
+    public static CommissionResponseDto from(CommissionDocumentEntity commissionDocumentEntity) {
         return new CommissionResponseDto(
                 commissionDocumentEntity.getCode(),
                 commissionDocumentEntity.getTitle(),

--- a/search-service/src/main/java/com/example/searchservice/commission/dto/CommissionResponseDto.java
+++ b/search-service/src/main/java/com/example/searchservice/commission/dto/CommissionResponseDto.java
@@ -1,0 +1,34 @@
+package com.example.searchservice.commission.dto;
+
+import com.example.searchservice.commission.common.PaymentType;
+import com.example.searchservice.commission.entity.CommissionDocumentEntity;
+import java.time.LocalDate;
+import java.util.List;
+
+public record CommissionResponseDto(
+        String code,
+        String title,
+        String memberCode,
+        String memberNickname,
+        List<String> tags,
+        LocalDate startedAt,
+        LocalDate endedAt,
+        PaymentType paymentType,
+        Long payAmount,
+        Boolean isClosed
+) {
+    public CommissionResponseDto from(CommissionDocumentEntity commissionDocumentEntity) {
+        return new CommissionResponseDto(
+                commissionDocumentEntity.getCode(),
+                commissionDocumentEntity.getTitle(),
+                commissionDocumentEntity.getMemberCode(),
+                commissionDocumentEntity.getMemberNickname(),
+                commissionDocumentEntity.getTags(),
+                commissionDocumentEntity.getStartedAt(),
+                commissionDocumentEntity.getEndedAt(),
+                commissionDocumentEntity.getPaymentType(),
+                commissionDocumentEntity.getPayAmount(),
+                commissionDocumentEntity.getIsClosed()
+        );
+    }
+}

--- a/search-service/src/main/java/com/example/searchservice/commission/entity/CommissionDocumentEntity.java
+++ b/search-service/src/main/java/com/example/searchservice/commission/entity/CommissionDocumentEntity.java
@@ -14,6 +14,7 @@ import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Setting;
 
 @Getter
 @Setter
@@ -21,6 +22,7 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 @NoArgsConstructor
 @AllArgsConstructor
 @Document(indexName = "commissions", createIndex = false)
+@Setting(settingPath = "elasticsearch/commissions-settings.json")
 public class CommissionDocumentEntity {
 
     @Id
@@ -31,6 +33,9 @@ public class CommissionDocumentEntity {
 
     @Field(type = FieldType.Text)
     private String content;
+
+    @Field(type = FieldType.Keyword)
+    private String memberCode;
 
     @Field(type = FieldType.Keyword, name = "member_nickname")
     private String memberNickname;

--- a/search-service/src/main/java/com/example/searchservice/commission/repository/CommissionRepository.java
+++ b/search-service/src/main/java/com/example/searchservice/commission/repository/CommissionRepository.java
@@ -1,8 +1,48 @@
 package com.example.searchservice.commission.repository;
 
+import com.example.searchservice.commission.dto.CommissionResponseDto;
 import com.example.searchservice.commission.entity.CommissionDocumentEntity;
+import com.example.searchservice.selfpromotion.entity.SelfPromotionDocumentEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 public interface CommissionRepository extends ElasticsearchRepository<CommissionDocumentEntity, String> {
 
+    @Query("""
+            {
+              "multi_match": {
+                "query": "#{#q}",
+                "fields": ["title", "content"],
+                "operator": "or",
+                "fuzziness": "1"
+              }
+            }
+            """)
+    Page<CommissionDocumentEntity> searchAll(String query, Pageable pageable);
+
+    @Query("""
+            {
+              "match": {
+                "title": {
+                  "query": "#{#q}",
+                  "fuzziness": "1"
+                }
+              }
+            }
+            """)
+    Page<CommissionDocumentEntity> searchTitle(String query, Pageable pageable);
+
+    @Query("""
+            {
+              "match": {
+                "content": {
+                  "query": "#{#q}",
+                  "fuzziness": "1"
+                }
+              }
+            }
+            """)
+    Page<CommissionDocumentEntity> searchContent(String query, Pageable pageable);
 }

--- a/search-service/src/main/java/com/example/searchservice/commission/service/CommissionInitializer.java
+++ b/search-service/src/main/java/com/example/searchservice/commission/service/CommissionInitializer.java
@@ -1,0 +1,55 @@
+package com.example.searchservice.commission.service;
+
+import com.example.searchservice.commission.common.PaymentType;
+import com.example.searchservice.commission.entity.CommissionDocumentEntity;
+import com.example.searchservice.commission.repository.CommissionRepository;
+import com.example.searchservice.selfpromotion.entity.SelfPromotionDocumentEntity;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommissionInitializer {
+
+    private final CommissionRepository commissionRepository;
+
+    // 테스트용 메소드
+    @EventListener(ApplicationReadyEvent.class)
+    public void initIndex() {
+        commissionRepository.save(CommissionDocumentEntity.builder()
+                .code("cms-001")
+                .title("Spring 개발자 구합니다.")
+                .content("Spring 백엔드 개발 가능하신 분 구합니다.")
+                .memberCode("m-001")
+                .memberNickname("스프링고수구함")
+                .tags(List.of("Spring", "Spring Boot", "Java"))
+                .startedAt(LocalDate.now())
+                .endedAt(LocalDate.now())
+                .paymentType(PaymentType.MONTHLY)
+                .payAmount(3_000_000L)
+                .isClosed(false)
+                .updatedAt(Instant.now())
+                .build());
+
+        commissionRepository.save(CommissionDocumentEntity.builder()
+                .code("cms-002")
+                .title("React 개발자 구합니다.")
+                .content("React 프론트엔드 개발 가능하신 분 구합니다.")
+                .memberCode("m-002")
+                .memberNickname("리액트고수구함")
+                .tags(List.of("React", "JavaScript"))
+                .startedAt(LocalDate.now())
+                .endedAt(LocalDate.now())
+                .paymentType(PaymentType.MONTHLY)
+                .payAmount(2_500_000L)
+                .isClosed(false)
+                .updatedAt(Instant.now())
+                .build());
+    }
+}

--- a/search-service/src/main/java/com/example/searchservice/commission/service/CommissionService.java
+++ b/search-service/src/main/java/com/example/searchservice/commission/service/CommissionService.java
@@ -1,5 +1,10 @@
 package com.example.searchservice.commission.service;
 
+import com.example.searchservice.commission.dto.CommissionResponseDto;
+import com.example.searchservice.common.vo.SearchScope;
+import org.springframework.data.domain.Page;
+
 public interface CommissionService {
 
+    public Page<CommissionResponseDto> search(String query, SearchScope scope, int page, int size);
 }

--- a/search-service/src/main/java/com/example/searchservice/commission/service/CommissionServiceImpl.java
+++ b/search-service/src/main/java/com/example/searchservice/commission/service/CommissionServiceImpl.java
@@ -1,8 +1,41 @@
 package com.example.searchservice.commission.service;
 
+import com.example.searchservice.commission.dto.CommissionResponseDto;
+import com.example.searchservice.commission.repository.CommissionRepository;
+import com.example.searchservice.common.vo.SearchScope;
+import com.example.searchservice.selfpromotion.dto.SelfPromotionResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class CommissionServiceImpl implements CommissionService {
 
+    private final CommissionRepository commissionRepository;
+
+    @Override
+    public Page<CommissionResponseDto> search(String query, SearchScope scope, int page, int size) {
+
+        if (query == null || query.isBlank()) {
+            PageRequest sortedByUpdatedAt = PageRequest.of(
+                    page,
+                    size,
+                    Sort.by(Sort.Direction.DESC, "updatedAt")
+            );
+
+            return commissionRepository.findAll(sortedByUpdatedAt)
+                    .map(CommissionResponseDto::from);
+        }
+
+        PageRequest pageable = PageRequest.of(page, size);
+
+        return switch (scope) {
+            case all       -> commissionRepository.searchAll(query, pageable).map(CommissionResponseDto::from);
+            case title     -> commissionRepository.searchTitle(query, pageable).map(CommissionResponseDto::from);
+            case content   -> commissionRepository.searchContent(query, pageable).map(CommissionResponseDto::from);
+        };
+    }
 }

--- a/search-service/src/main/java/com/example/searchservice/common/config/OpenApiConfig.java
+++ b/search-service/src/main/java/com/example/searchservice/common/config/OpenApiConfig.java
@@ -1,0 +1,30 @@
+package com.example.searchservice.common.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        servers = {
+                @Server(url = "http://localhost:8000", description = "Gateway URL")
+        }
+)
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("검색 모듈의 API")
+                .version("v1.0.0")
+                .description("검색 모듈의 API 명세서입니다.");
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(info);
+    }
+}

--- a/search-service/src/main/java/com/example/searchservice/common/config/RestTemplateConfiguration.java
+++ b/search-service/src/main/java/com/example/searchservice/common/config/RestTemplateConfiguration.java
@@ -1,4 +1,4 @@
-package com.example.searchservice.config;
+package com.example.searchservice.common.config;
 
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;

--- a/search-service/src/main/java/com/example/searchservice/selfpromotion/controller/swagger/SelfPromotionControllerSwagger.java
+++ b/search-service/src/main/java/com/example/searchservice/selfpromotion/controller/swagger/SelfPromotionControllerSwagger.java
@@ -35,6 +35,7 @@ public interface SelfPromotionControllerSwagger {
             @Parameter(name = "size", description = "보여줄 추천 검색 키워드 개수", required = false)
     })
     BaseResponse<Object> suggest(
-            String query, int size
+            String query,
+            int size
     );
 }

--- a/search-service/src/main/java/com/example/searchservice/selfpromotion/controller/swagger/SelfPromotionControllerSwagger.java
+++ b/search-service/src/main/java/com/example/searchservice/selfpromotion/controller/swagger/SelfPromotionControllerSwagger.java
@@ -13,11 +13,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "Self Promotion Search API", description = "Self Promotion 검색 / 검색 키워드 추천 API")
-@OpenAPIDefinition(
-        servers = {
-                @Server(url = "http://localhost:8000", description = "Gateway URL")
-        }
-)
 public interface SelfPromotionControllerSwagger {
 
     @Operation(summary = "Self Promotion 검색", description = "검색어, 검색 범위를 기반으로 Self Promotion을 검색합니다.")

--- a/search-service/src/main/java/com/example/searchservice/selfpromotion/repository/SelfPromotionRepository.java
+++ b/search-service/src/main/java/com/example/searchservice/selfpromotion/repository/SelfPromotionRepository.java
@@ -18,7 +18,7 @@ public interface SelfPromotionRepository extends ElasticsearchRepository<SelfPro
               }
             }
             """)
-    Page<SelfPromotionDocumentEntity> searchAll(String q, Pageable pageable);
+    Page<SelfPromotionDocumentEntity> searchAll(String query, Pageable pageable);
 
     @Query("""
             {
@@ -30,7 +30,7 @@ public interface SelfPromotionRepository extends ElasticsearchRepository<SelfPro
               }
             }
             """)
-    Page<SelfPromotionDocumentEntity> searchTitle(String q, Pageable pageable);
+    Page<SelfPromotionDocumentEntity> searchTitle(String query, Pageable pageable);
 
     @Query("""
             {
@@ -42,5 +42,5 @@ public interface SelfPromotionRepository extends ElasticsearchRepository<SelfPro
               }
             }
             """)
-    Page<SelfPromotionDocumentEntity> searchContent(String q, Pageable pageable);
+    Page<SelfPromotionDocumentEntity> searchContent(String query, Pageable pageable);
 }

--- a/search-service/src/main/java/com/example/searchservice/selfpromotion/service/SelfPromotionService.java
+++ b/search-service/src/main/java/com/example/searchservice/selfpromotion/service/SelfPromotionService.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Page;
 
 public interface SelfPromotionService {
 
-    public Page<SelfPromotionResponseDto> search(String q, SearchScope scope, int page, int size);
+    public Page<SelfPromotionResponseDto> search(String query, SearchScope scope, int page, int size);
 }

--- a/search-service/src/main/java/com/example/searchservice/selfpromotion/service/mapper/SelfPromotionMapper.java
+++ b/search-service/src/main/java/com/example/searchservice/selfpromotion/service/mapper/SelfPromotionMapper.java
@@ -1,6 +1,5 @@
 package com.example.searchservice.selfpromotion.service.mapper;
 
-import com.example.searchservice.selfpromotion.dto.SelfPromotionResponseDto;
 import com.example.searchservice.selfpromotion.entity.SelfPromotionDocumentEntity;
 import com.example.searchservice.selfpromotion.service.dto.ProfileSelfPromotionDto;
 

--- a/search-service/src/main/java/com/example/searchservice/tag/controller/swagger/TagControllerSwagger.java
+++ b/search-service/src/main/java/com/example/searchservice/tag/controller/swagger/TagControllerSwagger.java
@@ -15,11 +15,6 @@ import java.util.List;
 import org.springframework.validation.annotation.Validated;
 
 @Tag(name = "Tag Suggest API", description = "Tag 검색어 추천 API")
-@OpenAPIDefinition(
-        servers = {
-                @Server(url = "http://localhost:8000", description = "Gateway URL")
-        }
-)
 @Validated
 public interface TagControllerSwagger {
 

--- a/search-service/src/main/java/com/example/searchservice/tag/controller/swagger/TagControllerSwagger.java
+++ b/search-service/src/main/java/com/example/searchservice/tag/controller/swagger/TagControllerSwagger.java
@@ -2,9 +2,11 @@ package com.example.searchservice.tag.controller.swagger;
 
 import com.example.searchservice.common.response.BaseResponse;
 import com.example.searchservice.tag.dto.TagResponseDto;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -13,6 +15,11 @@ import java.util.List;
 import org.springframework.validation.annotation.Validated;
 
 @Tag(name = "Tag Suggest API", description = "Tag 검색어 추천 API")
+@OpenAPIDefinition(
+        servers = {
+                @Server(url = "http://localhost:8000", description = "Gateway URL")
+        }
+)
 @Validated
 public interface TagControllerSwagger {
 

--- a/search-service/src/main/resources/elasticsearch/commissoions-settings.json
+++ b/search-service/src/main/resources/elasticsearch/commissoions-settings.json
@@ -1,0 +1,61 @@
+{
+  "analysis": {
+    "tokenizer": {
+      "korean_tokenizer": {
+        "type": "nori_tokenizer",
+        "decompound_mode": "none"
+      }
+    },
+    "filter": {
+      "nori_postfilter": {
+        "type": "nori_part_of_speech",
+        "stoptags": [
+          "IC", "MAG", "MAJ",
+          "MM", "SP", "SSC", "SSO", "SC",
+          "SE", "XPN", "XSA", "XSN", "XSV",
+          "UNA", "NA", "VSV"
+        ]
+      },
+      "ko_en_synonym": {
+        "type": "synonym",
+        "expand": true,
+        "lenient": true,
+        "synonyms": [
+          "스프링부트, spring boot",
+          "스프링, spring",
+          "리액트, react",
+          "자바스크립트, javascript, js",
+          "자바, java"
+        ]
+      },
+      "edge_ngram_2_20": {
+        "type": "edge_ngram",
+        "min_gram": 2,
+        "max_gram": 20
+      }
+    },
+    "analyzer": {
+      "self_promotion_index_analyzer": {
+        "type": "custom",
+        "tokenizer": "korean_tokenizer",
+        "filter": [
+          "nori_readingform",
+          "nori_postfilter",
+          "lowercase",
+          "ko_en_synonym",
+          "edge_ngram_2_20"
+        ]
+      },
+      "self_promotion_search_analyzer": {
+        "type": "custom",
+        "tokenizer": "korean_tokenizer",
+        "filter": [
+          "nori_readingform",
+          "nori_postfilter",
+          "lowercase",
+          "ko_en_synonym"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 📌 목적
- 의뢰글 검색 기능을 개발합니다.

## ✅ 변경 사항
- 다중 필터링 조건은 구현이 까다로워 추후에 진행하게 될 것 같습니다.

## 🧪 테스트 방법
- discovery-service 실행 후 search-service 실행 하시면 됩니다.
- http://localhost:{search-service포트}/api/search/commissions?query={검색어}&scope={검색_범위(all|title|content)}

## 📎 참고 사항
<img width="645" height="904" alt="스크린샷 2025-11-16 오후 7 34 03" src="https://github.com/user-attachments/assets/e82860d2-0b37-4b3f-a494-697bb8c1c6cd" />


## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [x] 코드 컨벤션을 모두 지켰나요?
- [x] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
