### PR TITLE
feat(payment): 결제(예치금 충전) 기본 모듈 생성

### DIFF
--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -23,10 +23,22 @@ ext {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 dependencyManagement {

--- a/payment-service/src/main/java/com/example/paymentservice/common/config/JpaConfig.java
+++ b/payment-service/src/main/java/com/example/paymentservice/common/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.example.paymentservice.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/payment-service/src/main/java/com/example/paymentservice/common/config/OpenApiConfig.java
+++ b/payment-service/src/main/java/com/example/paymentservice/common/config/OpenApiConfig.java
@@ -12,7 +12,7 @@ public class OpenApiConfig {
     public OpenAPI openAPI() {
 
         Info info = new Info()
-                .title("CartPost API")
+                .title("Payment API")
                 .version("v1.0.0")
                 .description("결제 API 명세서입니다.");
 

--- a/payment-service/src/main/java/com/example/paymentservice/common/config/OpenApiConfig.java
+++ b/payment-service/src/main/java/com/example/paymentservice/common/config/OpenApiConfig.java
@@ -1,0 +1,22 @@
+package com.example.paymentservice.common.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+
+        Info info = new Info()
+                .title("CartPost API")
+                .version("v1.0.0")
+                .description("결제 API 명세서입니다.");
+
+        return new OpenAPI()
+                .info(info);
+    }
+}

--- a/payment-service/src/main/java/com/example/paymentservice/common/dto/EmptyResponse.java
+++ b/payment-service/src/main/java/com/example/paymentservice/common/dto/EmptyResponse.java
@@ -1,0 +1,13 @@
+package com.example.paymentservice.common.dto;
+
+public final class EmptyResponse {
+
+    private static final EmptyResponse INSTANCE = new EmptyResponse();
+
+    private EmptyResponse() {
+    }
+
+    public static EmptyResponse getInstance() {
+        return INSTANCE;
+    }
+}

--- a/payment-service/src/main/java/com/example/paymentservice/common/dto/ResponseDto.java
+++ b/payment-service/src/main/java/com/example/paymentservice/common/dto/ResponseDto.java
@@ -1,0 +1,44 @@
+package com.example.paymentservice.common.dto;
+
+import com.example.paymentservice.common.exception.ErrorCode;
+import com.example.paymentservice.common.exception.FieldErrorDetail;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.springframework.validation.BindingResult;
+
+public record ResponseDto<T>(
+        @Schema(description = "성공 및 실패에 대한 구체적인 개별 커스텀 코드", defaultValue = "0")
+        int code,
+
+        @JsonProperty("httpStatus")
+        @Schema(description = "상태코드", defaultValue = "200")
+        int httpStatusCode,
+
+        @Schema(description = "상태 메시지", defaultValue = "이상없음")
+        String message,
+
+        @Schema(description = "응답 내용")
+        T data
+) {
+
+    //data가 없는 에러 응답 (BusinessException)
+    public static ResponseDto<EmptyResponse> of(ErrorCode errorCode) {
+        return new ResponseDto<>(
+                errorCode.getCode(),
+                errorCode.getStatus().value(),
+                errorCode.getMessage(),
+                EmptyResponse.getInstance()
+        );
+    }
+
+    //@Valid 유효성 검사 에러 응답 (MethodArgumentNotValidException)
+    public static ResponseDto<List<FieldErrorDetail>> of(ErrorCode errorCode, BindingResult bindingResult) {
+        return new ResponseDto<>(
+                errorCode.getCode(),
+                errorCode.getStatus().value(),
+                errorCode.getMessage(),
+                FieldErrorDetail.of(bindingResult) // data에 필드 에러 목록 추가
+        );
+    }
+}

--- a/payment-service/src/main/java/com/example/paymentservice/common/dto/ResponseDto.java
+++ b/payment-service/src/main/java/com/example/paymentservice/common/dto/ResponseDto.java
@@ -1,6 +1,6 @@
 package com.example.paymentservice.common.dto;
 
-import com.example.paymentservice.common.exception.ErrorCode;
+import com.example.paymentservice.common.dto.enums.CustomStatusCode;
 import com.example.paymentservice.common.exception.FieldErrorDetail;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -23,21 +23,21 @@ public record ResponseDto<T>(
 ) {
 
     //data가 없는 에러 응답 (BusinessException)
-    public static ResponseDto<EmptyResponse> of(ErrorCode errorCode) {
+    public static ResponseDto<EmptyResponse> of(CustomStatusCode customStatusCode) {
         return new ResponseDto<>(
-                errorCode.getCode(),
-                errorCode.getStatus().value(),
-                errorCode.getMessage(),
+                customStatusCode.getCode(),
+                customStatusCode.getStatus().value(),
+                customStatusCode.getMessage(),
                 EmptyResponse.getInstance()
         );
     }
 
     //@Valid 유효성 검사 에러 응답 (MethodArgumentNotValidException)
-    public static ResponseDto<List<FieldErrorDetail>> of(ErrorCode errorCode, BindingResult bindingResult) {
+    public static ResponseDto<List<FieldErrorDetail>> of(CustomStatusCode customStatusCode, BindingResult bindingResult) {
         return new ResponseDto<>(
-                errorCode.getCode(),
-                errorCode.getStatus().value(),
-                errorCode.getMessage(),
+                customStatusCode.getCode(),
+                customStatusCode.getStatus().value(),
+                customStatusCode.getMessage(),
                 FieldErrorDetail.of(bindingResult) // data에 필드 에러 목록 추가
         );
     }

--- a/payment-service/src/main/java/com/example/paymentservice/common/dto/enums/CustomStatusCode.java
+++ b/payment-service/src/main/java/com/example/paymentservice/common/dto/enums/CustomStatusCode.java
@@ -1,4 +1,4 @@
-package com.example.paymentservice.common.exception;
+package com.example.paymentservice.common.dto.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum ErrorCode {
+public enum CustomStatusCode {
     SUCCESS(HttpStatus.OK, 0, "성공");
 
 

--- a/payment-service/src/main/java/com/example/paymentservice/common/exception/BusinessException.java
+++ b/payment-service/src/main/java/com/example/paymentservice/common/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package com.example.paymentservice.common.exception;
+
+import com.example.paymentservice.common.dto.enums.CustomStatusCode;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final CustomStatusCode customStatusCode;
+
+    public BusinessException(CustomStatusCode customStatusCode) {
+        super(customStatusCode.getMessage()); // RuntimeException의 message 필드에 메시지를 설정합니다.
+        this.customStatusCode = customStatusCode;
+    }
+}

--- a/payment-service/src/main/java/com/example/paymentservice/common/exception/ErrorCode.java
+++ b/payment-service/src/main/java/com/example/paymentservice/common/exception/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.example.paymentservice.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    SUCCESS(HttpStatus.OK, 0, "성공");
+
+
+    private final HttpStatus status;
+    private final int code;
+    private final String message;
+}

--- a/payment-service/src/main/java/com/example/paymentservice/common/exception/FieldErrorDetail.java
+++ b/payment-service/src/main/java/com/example/paymentservice/common/exception/FieldErrorDetail.java
@@ -1,0 +1,33 @@
+package com.example.paymentservice.common.exception;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+public class FieldErrorDetail {
+
+    @Schema(description = "에러가 발생한 필드명", example = "email")
+    private String field;
+
+    @Schema(description = "에러가 발생한 이유 (검증 메시지)", example = "이메일 형식이 올바르지 않습니다.")
+    private String reason;
+
+    @Schema(description = "제출된 잘못된 값", example = "testUser@")
+    private String value;
+
+    private FieldErrorDetail(FieldError error) {
+        this.field = error.getField();
+        this.reason = error.getDefaultMessage();
+        this.value = error.getRejectedValue() != null ? error.getRejectedValue().toString() : "null";
+    }
+
+    public static List<FieldErrorDetail> of(BindingResult bindingResult) {
+        List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+        return fieldErrors.stream()
+                .map(FieldErrorDetail::new)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/payment-service/src/main/java/com/example/paymentservice/common/exception/GlobalExceptionHandler.java
+++ b/payment-service/src/main/java/com/example/paymentservice/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package com.example.paymentservice.common.exception;
+
+import com.example.paymentservice.common.dto.EmptyResponse;
+import com.example.paymentservice.common.dto.ResponseDto;
+import com.example.paymentservice.common.dto.enums.CustomStatusCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ResponseDto<EmptyResponse>> handleBusinessException(BusinessException ex) {
+        log.warn("handleBusinessException: {}", ex.getMessage());
+
+        CustomStatusCode customStatusCode = ex.getCustomStatusCode();
+        ResponseDto response = ResponseDto.of(customStatusCode);
+
+        return new ResponseEntity<>(response, customStatusCode.getStatus());
+    }
+
+
+    //    @ExceptionHandler(MethodArgumentNotValidException.class)
+//    protected ResponseEntity<ResponseDto<List<FieldErrorDetail>>> handleMethodArgumentNotValidException(
+//            MethodArgumentNotValidException ex) {
+//        log.warn("handleMethodArgumentNotValidException: {}", ex.getMessage());
+//
+//        BindingResult bindingResult = ex.getBindingResult();
+//        ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+//
+//        // ResponseDto의 오버로딩된 of() 사용
+//        ResponseDto<List<FieldErrorDetail>> response = ResponseDto.of(errorCode, bindingResult);
+//
+//        return new ResponseEntity<>(response, errorCode.getStatus());
+//    }
+//
+//
+//    @ExceptionHandler(Exception.class)
+//    protected ResponseEntity<ResponseDto<EmptyDto>> handleGeneralException(Exception ex) {
+//        log.error("handleGeneralException: {}", ex.getMessage(), ex); // 스택 트레이스 로깅
+//
+//        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+//        ResponseDto response = ResponseDto.of(errorCode);
+//
+//        return new ResponseEntity<>(response, errorCode.getStatus());
+//    }
+}

--- a/payment-service/src/main/java/com/example/paymentservice/common/model/BaseEntity.java
+++ b/payment-service/src/main/java/com/example/paymentservice/common/model/BaseEntity.java
@@ -1,0 +1,46 @@
+package com.example.paymentservice.common.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    @Column(nullable = false, unique = true)
+    private String code;
+
+    @Column(nullable = false)
+    private boolean is_deleted = false;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @PrePersist
+    public void generateCode() {
+        if (this.code == null) {
+            this.code = UUID.randomUUID().toString();
+        }
+    }
+}

--- a/payment-service/src/main/java/com/example/paymentservice/common/model/BaseEntity.java
+++ b/payment-service/src/main/java/com/example/paymentservice/common/model/BaseEntity.java
@@ -27,7 +27,7 @@ public abstract class BaseEntity {
     private String code;
 
     @Column(nullable = false)
-    private boolean isDeleted;
+    private boolean isDeleted = false;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)
@@ -42,9 +42,8 @@ public abstract class BaseEntity {
         if (this.code == null) {
             this.code = UUID.randomUUID().toString();
         }
-        if(this.isDeleted) {
-            this.isDeleted = false;
-        }
+
+        prePersistHook();
     }
 
     public void delete() {

--- a/payment-service/src/main/java/com/example/paymentservice/common/model/BaseEntity.java
+++ b/payment-service/src/main/java/com/example/paymentservice/common/model/BaseEntity.java
@@ -27,7 +27,7 @@ public abstract class BaseEntity {
     private String code;
 
     @Column(nullable = false)
-    private boolean is_deleted = false;
+    private boolean isDeleted;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)
@@ -38,9 +38,18 @@ public abstract class BaseEntity {
     private Instant updatedAt;
 
     @PrePersist
-    public void generateCode() {
+    public void runPrePersist() {
         if (this.code == null) {
             this.code = UUID.randomUUID().toString();
         }
+        if(this.isDeleted) {
+            this.isDeleted = false;
+        }
     }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+
+    protected void prePersistHook() {}
 }

--- a/payment-service/src/main/java/com/example/paymentservice/payment/controller/PaymentApi.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/controller/PaymentApi.java
@@ -2,6 +2,8 @@ package com.example.paymentservice.payment.controller;
 
 import com.example.paymentservice.common.dto.ResponseDto;
 import com.example.paymentservice.payment.controller.dto.response.PayRechargeResponse;
+import com.example.paymentservice.payment.controller.dto.response.PaymentGetResponse;
+import com.example.paymentservice.payment.controller.dto.response.PaymentsGetResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -10,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "Payment API", description = "결제(충전) API 명세")
@@ -31,7 +34,30 @@ public interface PaymentApi {
     })
     ResponseEntity<ResponseDto<PayRechargeResponse>> payForRecharge(
             @RequestHeader(name = "X-CODE") String code,
-            String amount
+            @PathVariable String amount
     );
+
+    @Operation(summary = "결제 목록 조회", description = "모든 결제 목록을 조회합니다.")
+    @Parameters({
+            @Parameter(name = "X-CODE", description = "사용자 인증용 코드 (헤더)", required = true, in = ParameterIn.HEADER)
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "결제 목록 조회 성공"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    ResponseEntity<ResponseDto<PaymentsGetResponse>> getAllPayments(@RequestHeader(name = "X-CODE") String code);
+
+    @Operation(summary = "결제 상세 조회", description = "특정 주문 코드(orderId)를 기준으로 결제 상세 정보를 조회합니다.")
+    @Parameters({
+            @Parameter(name = "X-CODE", description = "사용자 인증용 코드 (헤더)", required = true, in = ParameterIn.HEADER),
+            @Parameter(name = "order-code", description = "조회할 주문 코드(orderId)", required = true, example = "123e4567-e89b-12d3-a456-426614174000", in = ParameterIn.PATH)
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "결제 상세 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 주문 결제 정보 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    ResponseEntity<ResponseDto<PaymentGetResponse>> getPaymentByOrderCode(@RequestHeader(name = "X-CODE") String code,
+            @PathVariable("order-pg-id") String orderPgId);
 }
 

--- a/payment-service/src/main/java/com/example/paymentservice/payment/controller/PaymentApi.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/controller/PaymentApi.java
@@ -1,0 +1,37 @@
+package com.example.paymentservice.payment.controller;
+
+import com.example.paymentservice.common.dto.ResponseDto;
+import com.example.paymentservice.payment.controller.dto.response.PayRechargeResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "Payment API", description = "결제(충전) API 명세")
+public interface PaymentApi {
+
+    @Operation(
+            summary = "충전 결제 요청",
+            description = "X-CODE 헤더와 금액(amount)을 기반으로 충전 결제를 요청합니다."
+    )
+    @Parameters({
+            @Parameter(name = "X-CODE", description = "사용자 인증용 코드 (헤더)", required = true, in = ParameterIn.HEADER),
+            @Parameter(name = "amount", description = "충전할 금액", required = true, example = "1000")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "결제 요청 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 코드 또는 금액)"),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (X-CODE 헤더 없음 또는 유효하지 않음)"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    ResponseEntity<ResponseDto<PayRechargeResponse>> payForRecharge(
+            @RequestHeader(name = "X-CODE") String code,
+            String amount
+    );
+}
+

--- a/payment-service/src/main/java/com/example/paymentservice/payment/controller/PaymentController.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/controller/PaymentController.java
@@ -1,0 +1,20 @@
+package com.example.paymentservice.payment.controller;
+
+import com.example.paymentservice.common.dto.ResponseDto;
+import com.example.paymentservice.payment.controller.dto.response.PayRechargeResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/payments")
+public class PaymentController implements PaymentApi {
+
+    @Override
+    public ResponseEntity<ResponseDto<PayRechargeResponse>> payForRecharge(String code, String amount) {
+        return null;
+    }
+}

--- a/payment-service/src/main/java/com/example/paymentservice/payment/controller/PaymentController.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/controller/PaymentController.java
@@ -2,9 +2,12 @@ package com.example.paymentservice.payment.controller;
 
 import com.example.paymentservice.common.dto.ResponseDto;
 import com.example.paymentservice.payment.controller.dto.response.PayRechargeResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import com.example.paymentservice.payment.controller.dto.response.PaymentGetResponse;
+import com.example.paymentservice.payment.controller.dto.response.PaymentsGetResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,7 +17,23 @@ import org.springframework.web.bind.annotation.RestController;
 public class PaymentController implements PaymentApi {
 
     @Override
-    public ResponseEntity<ResponseDto<PayRechargeResponse>> payForRecharge(String code, String amount) {
+    @PostMapping("/charge")
+    public ResponseEntity<ResponseDto<PayRechargeResponse>> payForRecharge(@RequestHeader(name = "X-CODE") String code,
+            @PathVariable String amount) {
+        return null;
+    }
+
+    @Override
+    @GetMapping("/orders")
+    public ResponseEntity<ResponseDto<PaymentsGetResponse>> getAllPayments(
+            @RequestHeader(name = "X-CODE") String code) {
+        return null;
+    }
+
+    @Override
+    @GetMapping("/orders/{order-pg-id}")
+    public ResponseEntity<ResponseDto<PaymentGetResponse>> getPaymentByOrderCode(
+            @RequestHeader(name = "X-CODE") String code, @PathVariable("order-pg-id") String orderPgId) {
         return null;
     }
 }

--- a/payment-service/src/main/java/com/example/paymentservice/payment/controller/dto/response/PayRechargeResponse.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/controller/dto/response/PayRechargeResponse.java
@@ -1,0 +1,5 @@
+package com.example.paymentservice.payment.controller.dto.response;
+
+public record PayRechargeResponse() {
+
+}

--- a/payment-service/src/main/java/com/example/paymentservice/payment/controller/dto/response/PaymentGetResponse.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/controller/dto/response/PaymentGetResponse.java
@@ -1,0 +1,5 @@
+package com.example.paymentservice.payment.controller.dto.response;
+
+public record PaymentGetResponse() {
+
+}

--- a/payment-service/src/main/java/com/example/paymentservice/payment/controller/dto/response/PaymentsGetResponse.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/controller/dto/response/PaymentsGetResponse.java
@@ -1,0 +1,5 @@
+package com.example.paymentservice.payment.controller.dto.response;
+
+public record PaymentsGetResponse() {
+
+}

--- a/payment-service/src/main/java/com/example/paymentservice/payment/model/OrderEntity.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/model/OrderEntity.java
@@ -1,0 +1,37 @@
+package com.example.paymentservice.payment.model;
+
+import com.example.paymentservice.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "orders")
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderEntity extends BaseEntity {
+
+    @Column(nullable = false, updatable = false)
+    private String memberCode;
+
+    @Column(nullable = false, unique = true, updatable = false)
+    private String orderPgId;
+
+    @Override
+    public void prePersistHook() {
+        if (this.orderPgId == null) {
+            this.orderPgId = UUID.randomUUID().toString();
+        }
+    }
+
+    @Builder
+    public OrderEntity(String memberCode) {
+        this.memberCode = memberCode;
+    }
+}
+

--- a/payment-service/src/main/java/com/example/paymentservice/payment/model/PaymentEntity.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/model/PaymentEntity.java
@@ -1,0 +1,44 @@
+package com.example.paymentservice.payment.model;
+
+import com.example.paymentservice.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "payments")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentEntity extends BaseEntity {
+
+    @Column(nullable = false, unique = true, updatable = false)
+    private String orderPgId;     // OrderEntity와 논리적 연결
+
+    @Column(updatable = false)
+    private String paymentKey;  // PG사 고유 키
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus paymentStatus;
+
+    @Builder
+    public PaymentEntity(String orderPgId, String paymentKey, Long amount, PaymentStatus paymentStatus) {
+        this.orderPgId = orderPgId;
+        this.paymentKey = paymentKey;
+        this.amount = amount;
+        this.paymentStatus = paymentStatus;
+    }
+}
+
+

--- a/payment-service/src/main/java/com/example/paymentservice/payment/model/PaymentStatus.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/model/PaymentStatus.java
@@ -1,0 +1,7 @@
+package com.example.paymentservice.payment.model;
+
+public enum PaymentStatus {
+    PAYMENT_COMPLETED,
+    PAYMENT_FAILED,
+    REFUNDED
+}

--- a/payment-service/src/main/java/com/example/paymentservice/payment/repository/OrderRepository.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/repository/OrderRepository.java
@@ -1,0 +1,13 @@
+package com.example.paymentservice.payment.repository;
+
+import com.example.paymentservice.payment.model.OrderEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface OrderRepository extends JpaRepository<OrderEntity, Long> {
+
+}
+

--- a/payment-service/src/main/java/com/example/paymentservice/payment/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/repository/PaymentRepository.java
@@ -1,0 +1,14 @@
+package com.example.paymentservice.payment.repository;
+
+import com.example.paymentservice.payment.model.PaymentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PaymentRepository extends JpaRepository<PaymentEntity, Long> {
+
+}
+

--- a/payment-service/src/main/java/com/example/paymentservice/payment/service/PaymentService.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/service/PaymentService.java
@@ -1,0 +1,16 @@
+package com.example.paymentservice.payment.service;
+
+import com.example.paymentservice.payment.service.dto.response.PayRechargeResult;
+import com.example.paymentservice.payment.service.dto.response.PaymentGetResult;
+import com.example.paymentservice.payment.service.dto.response.PaymentsGetResult;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface PaymentService {
+
+    public PayRechargeResult payForRecharge(String code, String amount);
+
+    public PaymentsGetResult getAllPayments(String code);
+
+    public PaymentGetResult getPaymentByOrderCode(String code, String orderPgId);
+}

--- a/payment-service/src/main/java/com/example/paymentservice/payment/service/PaymentServiceImpl.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/service/PaymentServiceImpl.java
@@ -1,0 +1,25 @@
+package com.example.paymentservice.payment.service;
+
+import com.example.paymentservice.payment.service.dto.response.PayRechargeResult;
+import com.example.paymentservice.payment.service.dto.response.PaymentGetResult;
+import com.example.paymentservice.payment.service.dto.response.PaymentsGetResult;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PaymentServiceImpl implements PaymentService {
+
+    @Override
+    public PayRechargeResult payForRecharge(String code, String amount) {
+        return null;
+    }
+
+    @Override
+    public PaymentsGetResult getAllPayments(String code) {
+        return null;
+    }
+
+    @Override
+    public PaymentGetResult getPaymentByOrderCode(String code, String orderPgId) {
+        return null;
+    }
+}

--- a/payment-service/src/main/java/com/example/paymentservice/payment/service/dto/response/PayRechargeResult.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/service/dto/response/PayRechargeResult.java
@@ -1,0 +1,5 @@
+package com.example.paymentservice.payment.service.dto.response;
+
+public record PayRechargeResult() {
+
+}

--- a/payment-service/src/main/java/com/example/paymentservice/payment/service/dto/response/PaymentGetResult.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/service/dto/response/PaymentGetResult.java
@@ -1,0 +1,5 @@
+package com.example.paymentservice.payment.service.dto.response;
+
+public record PaymentGetResult() {
+
+}

--- a/payment-service/src/main/java/com/example/paymentservice/payment/service/dto/response/PaymentsGetResult.java
+++ b/payment-service/src/main/java/com/example/paymentservice/payment/service/dto/response/PaymentsGetResult.java
@@ -1,0 +1,5 @@
+package com.example.paymentservice.payment.service.dto.response;
+
+public record PaymentsGetResult() {
+
+}

--- a/payment-service/src/main/resources/schema.sql
+++ b/payment-service/src/main/resources/schema.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS `payments` (
+      `id` BIGINT NOT NULL,
+      `member_code` CHAR(36) NOT NULL,
+      `code` CHAR(36) NOT NULL,
+      `created_at` TIMESTAMP NOT NULL,
+      `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      `is_deleted` BOOLEAN NOT NULL,
+      `total_amount` BIGINT NOT NULL,
+      `payment_key` VARCHAR(255) NOT NULL,
+      `pg_order_id` VARCHAR(255) NOT NULL,
+      `status` VARCHAR(20) NOT NULL,
+      PRIMARY KEY (`id`)
+);

--- a/payment-service/src/main/resources/schema.sql
+++ b/payment-service/src/main/resources/schema.sql
@@ -1,13 +1,22 @@
-CREATE TABLE IF NOT EXISTS `payments` (
-      `id` BIGINT NOT NULL,
-      `member_code` CHAR(36) NOT NULL,
-      `code` CHAR(36) NOT NULL,
-      `created_at` TIMESTAMP NOT NULL,
-      `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      `is_deleted` BOOLEAN NOT NULL,
-      `total_amount` BIGINT NOT NULL,
-      `payment_key` VARCHAR(255) NOT NULL,
-      `pg_order_id` VARCHAR(255) NOT NULL,
-      `status` VARCHAR(20) NOT NULL,
-      PRIMARY KEY (`id`)
+CREATE TABLE IF NOT EXISTS orders (
+                              id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                              code VARCHAR(255) NOT NULL UNIQUE,
+                              is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+                              created_at TIMESTAMP,
+                              updated_at TIMESTAMP,
+                              member_code VARCHAR(255) NOT NULL,
+                              order_pg_id VARCHAR(255) NOT NULL UNIQUE
 );
+
+CREATE TABLE IF NOT EXISTS payments (
+                          id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                          code VARCHAR(255) NOT NULL UNIQUE,
+                          is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+                          created_at TIMESTAMP,
+                          updated_at TIMESTAMP,
+                          order_pg_id VARCHAR(255) NOT NULL UNIQUE,
+                          payment_key VARCHAR(255),
+                          amount BIGINT NOT NULL,
+                          payment_status VARCHAR(255) NOT NULL
+);
+

--- a/payment-service/src/test/java/com/example/paymentservice/payment/service/PaymentServiceTest.java
+++ b/payment-service/src/test/java/com/example/paymentservice/payment/service/PaymentServiceTest.java
@@ -1,0 +1,34 @@
+package com.example.paymentservice.payment.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+    @Mock
+    private PaymentService paymentService; // 인터페이스를 Mock 처리
+
+    @Test
+    @DisplayName("payForRecharge 성공 테스트")
+    void testPayForRecharge() {
+
+    }
+
+    @Test
+    @DisplayName("getAllPayments 성공 테스트")
+    void testGetAllPayments() {
+
+    }
+
+    @Test
+    @DisplayName("getPaymentByOrderCode 성공 테스트")
+    void testGetPaymentByOrderCode() {
+
+    }
+}
+


### PR DESCRIPTION
## 📌 목적
- 결제 모듈의 api 기본 구성 생성이 목표입니다

## ✅ 변경 사항
- 결제 모듈에 대한 api controller, service, repository 생성
- 자동 테이블 생성 shecma.sql 설정
- swagger ui 연결
- h2 console 연결

## 🧪 테스트 방법
- localhost:8000/api/payments/swagger-ui 로 접속하여 api 확인
- localhost:{자동 할당 결제 모듈 port}/h2-console 

## 📎 참고 사항
- swagger 접속
<img width="1487" height="417" alt="image" src="https://github.com/user-attachments/assets/9a9ba970-df20-41a8-bcd3-5096eb4dc06e" />

- h2-console 접속
<img width="956" height="468" alt="image" src="https://github.com/user-attachments/assets/2402ee83-4a80-4edc-8ea2-fcb46e6dc26b" />



## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [x] 코드 컨벤션을 모두 지켰나요?
- [x] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
