### PR TITLE
feat(chat): 채팅방 생성 기능 구현

### DIFF
--- a/communication-service/build.gradle
+++ b/communication-service/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5' // Swagger
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb' // MongoDB
 }
 
 dependencyManagement {

--- a/communication-service/build.gradle
+++ b/communication-service/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5' // Swagger
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb' // MongoDB
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign' // FeignClient
 }
 
 dependencyManagement {

--- a/communication-service/src/main/java/com/example/communicationservice/client/MemberServiceClient.java
+++ b/communication-service/src/main/java/com/example/communicationservice/client/MemberServiceClient.java
@@ -1,0 +1,23 @@
+package com.example.communicationservice.client;
+
+import com.example.communicationservice.client.dto.MemberExistOutput;
+import com.example.communicationservice.common.response.ResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+// name: 호출 대상 서비스 이름, path: 기본 경로
+@FeignClient(
+    name = "member-service",
+    path = "/internal/members"
+)
+public interface MemberServiceClient {
+
+    @GetMapping("/exist")
+    ResponseDto<MemberExistOutput> getMemberExistences(
+        @RequestParam(name = "member-code") List<String> memberCodes
+    );
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/client/config/FeignClientConfiguration.java
+++ b/communication-service/src/main/java/com/example/communicationservice/client/config/FeignClientConfiguration.java
@@ -1,0 +1,9 @@
+package com.example.communicationservice.client.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackages = "com.example.communicationservice.client")
+public class FeignClientConfiguration {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/client/config/FeignClientErrorDecoder.java
+++ b/communication-service/src/main/java/com/example/communicationservice/client/config/FeignClientErrorDecoder.java
@@ -1,0 +1,61 @@
+package com.example.communicationservice.client.config;
+
+import com.example.communicationservice.client.exception.FeignClientException;
+import com.example.communicationservice.common.response.ResponseDto;
+import com.example.communicationservice.common.status.ResponseDtoStatus;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Response;
+import feign.Util;
+import feign.codec.ErrorDecoder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class FeignClientErrorDecoder implements ErrorDecoder {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+
+        try {
+            // body가 있는 경우 JSON 파싱 시도
+            if (response.body() != null) {
+                String body = Util.toString(response.body().asReader(StandardCharsets.UTF_8));
+
+                try {
+                    ResponseDto<?> errorResponse = objectMapper.readValue(body, new TypeReference<>() {});
+
+                    int httpStatusCode = errorResponse.getHttpStatusCode();
+
+                    return switch (httpStatusCode) {
+                        case 400 -> new FeignClientException(ResponseDtoStatus.FEIGN_BAD_REQUEST);
+                        case 401 -> new FeignClientException(ResponseDtoStatus.FEIGN_UNAUTHORIZED);
+                        case 403 -> new FeignClientException(ResponseDtoStatus.FEIGN_FORBIDDEN);
+                        case 404 -> new FeignClientException(ResponseDtoStatus.FEIGN_NOT_FOUND);
+                        case 500 -> new FeignClientException(ResponseDtoStatus.FEIGN_INTERNAL_SERVER_ERROR);
+                        default -> new FeignClientException(ResponseDtoStatus.FEIGN_UNKNOWN_ERROR);
+                    };
+
+                } catch (JsonProcessingException e) {
+                    // JSON 파싱 실패 시 알 수 없는 오류로 처리
+                    return new FeignClientException(ResponseDtoStatus.FEIGN_UNKNOWN_ERROR);
+                }
+            }
+
+            // body가 없는 경우 통신 문제로 처리
+            return new FeignClientException(ResponseDtoStatus.FEIGN_COMMUNICATION_ERROR);
+
+        } catch (IOException e) {
+            // body를 읽을 수 없는 경우 통신 문제로 처리
+            return new FeignClientException(ResponseDtoStatus.FEIGN_COMMUNICATION_ERROR);
+        }
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/client/dto/MemberExistOutput.java
+++ b/communication-service/src/main/java/com/example/communicationservice/client/dto/MemberExistOutput.java
@@ -1,0 +1,9 @@
+package com.example.communicationservice.client.dto;
+
+import java.util.List;
+
+public record MemberExistOutput(
+    List<String> exists, // 유효한 회원 코드 목록
+    List<String> notExists // 유효하지 않은 회원 코드 목록
+) {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/client/exception/FeignClientException.java
+++ b/communication-service/src/main/java/com/example/communicationservice/client/exception/FeignClientException.java
@@ -1,0 +1,12 @@
+package com.example.communicationservice.client.exception;
+
+import com.example.communicationservice.common.exception.CustomException;
+import com.example.communicationservice.common.status.ResponseDtoStatus;
+
+public class FeignClientException extends CustomException {
+
+    public FeignClientException(ResponseDtoStatus status) {
+        super(status);
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/common/exception/ChatRoomException.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/exception/ChatRoomException.java
@@ -1,0 +1,16 @@
+package com.example.communicationservice.common.exception;
+
+import com.example.communicationservice.common.status.ResponseDtoStatus;
+import lombok.Getter;
+
+@Getter
+public class ChatRoomException extends RuntimeException {
+
+    private final ResponseDtoStatus status;
+
+    public ChatRoomException(ResponseDtoStatus status) {
+        super(status.getMessage());
+        this.status = status;
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/common/exception/ChatRoomException.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/exception/ChatRoomException.java
@@ -1,16 +1,11 @@
 package com.example.communicationservice.common.exception;
 
 import com.example.communicationservice.common.status.ResponseDtoStatus;
-import lombok.Getter;
 
-@Getter
-public class ChatRoomException extends RuntimeException {
-
-    private final ResponseDtoStatus status;
+public class ChatRoomException extends CustomException {
 
     public ChatRoomException(ResponseDtoStatus status) {
-        super(status.getMessage());
-        this.status = status;
+        super(status);
     }
 
 }

--- a/communication-service/src/main/java/com/example/communicationservice/common/exception/CustomException.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/exception/CustomException.java
@@ -1,0 +1,16 @@
+package com.example.communicationservice.common.exception;
+
+import com.example.communicationservice.common.status.ResponseDtoStatus;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ResponseDtoStatus status;
+
+    public CustomException(ResponseDtoStatus status) {
+        super(status.getMessage());
+        this.status = status;
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/common/exception/GlobalExceptionHandler.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package com.example.communicationservice.common.exception;
+
+import com.example.communicationservice.common.response.Empty;
+import com.example.communicationservice.common.response.ResponseDto;
+import com.example.communicationservice.common.status.ResponseDtoStatus;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 유효성 검사 실패 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseDto<List<String>>> handleValidationException(MethodArgumentNotValidException ex) {
+        List<String> errors = ex.getBindingResult().getFieldErrors().stream()
+            .map(DefaultMessageSourceResolvable::getDefaultMessage)
+            .toList();
+
+        return ResponseEntity
+            .badRequest()
+            .body(ResponseDto.error(ResponseDtoStatus.VALIDATION_FAILED, errors));
+    }
+
+    // 채팅방 커스텀 예외 처리
+    @ExceptionHandler(ChatRoomException.class)
+    public ResponseEntity<ResponseDto<Empty>> handleChatRoomException(ChatRoomException ex) {
+        ResponseDtoStatus status = ex.getStatus();
+
+        return ResponseEntity
+            .status(status.getHttpStatusCode())
+            .body(ResponseDto.error(status));
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/common/exception/GlobalExceptionHandler.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/exception/GlobalExceptionHandler.java
@@ -26,9 +26,9 @@ public class GlobalExceptionHandler {
             .body(ResponseDto.error(ResponseDtoStatus.VALIDATION_FAILED, errors));
     }
 
-    // 채팅방 커스텀 예외 처리
-    @ExceptionHandler(ChatRoomException.class)
-    public ResponseEntity<ResponseDto<Empty>> handleChatRoomException(ChatRoomException ex) {
+    // 커스텀 예외 처리
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ResponseDto<Empty>> handleChatRoomException(CustomException ex) {
         ResponseDtoStatus status = ex.getStatus();
 
         return ResponseEntity

--- a/communication-service/src/main/java/com/example/communicationservice/common/response/Empty.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/response/Empty.java
@@ -1,5 +1,8 @@
 package com.example.communicationservice.common.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize(using = EmptySerializer.class)
 public final class Empty {
     private static final Empty INSTANCE = new Empty();
 

--- a/communication-service/src/main/java/com/example/communicationservice/common/response/Empty.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/response/Empty.java
@@ -1,0 +1,12 @@
+package com.example.communicationservice.common.response;
+
+public final class Empty {
+    private static final Empty INSTANCE = new Empty();
+
+    private Empty() {}
+
+    public static Empty getInstance() {
+        return INSTANCE;
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/common/response/EmptySerializer.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/response/EmptySerializer.java
@@ -1,0 +1,25 @@
+package com.example.communicationservice.common.response;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+public class EmptySerializer extends StdSerializer<Empty> {
+
+    public EmptySerializer() {
+        super(Empty.class);
+    }
+
+    @Override
+    public void serialize(
+        Empty value,
+        JsonGenerator generator,
+        SerializerProvider provider
+    ) throws IOException {
+        generator.writeStartObject(); // {
+        generator.writeEndObject(); // }
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/common/response/ResponseDto.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/response/ResponseDto.java
@@ -1,0 +1,44 @@
+package com.example.communicationservice.common.response;
+
+import com.example.communicationservice.common.status.ResponseDtoStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({"code", "httpStatus", "message", "data"})
+public class ResponseDto<T> {
+
+    private final int code;
+
+    @JsonProperty("httpStatus")
+    private final int httpStatusCode;
+
+    private final String message;
+
+    private final T data;
+
+    public static ResponseDto<Empty> success() {
+        return new ResponseDto<>(ResponseDtoStatus.SUCCESS, Empty.getInstance());
+    }
+
+    public static <T> ResponseDto<T> success(T result) {
+        return new ResponseDto<>(ResponseDtoStatus.SUCCESS, result);
+    }
+
+    public static ResponseDto<Empty> error(ResponseDtoStatus status) {
+        return new ResponseDto<>(status, Empty.getInstance());
+    }
+
+    public static <T> ResponseDto<T> error(ResponseDtoStatus status, T data) {
+        return new ResponseDto<>(status, data);
+    }
+
+    private ResponseDto(ResponseDtoStatus status, T data) {
+        this.code = status.getCode();
+        this.httpStatusCode = status.getHttpStatusCode();
+        this.message = status.getMessage();
+        this.data = data;
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/common/status/ResponseDtoStatus.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/status/ResponseDtoStatus.java
@@ -13,6 +13,7 @@ public enum ResponseDtoStatus {
     CHATROOM_INVALID_MEMBER_COUNT(1000, "1:1 채팅은 2명의 참여자가 필요합니다.", HttpStatus.BAD_REQUEST),
     CHATROOM_NOT_INCLUDE_SELF(1001, "현재 로그인한 사용자는 채팅방에 포함되어야 합니다.", HttpStatus.BAD_REQUEST),
     CHATROOM_ALREADY_EXISTS(1002, "이미 채팅방이 존재합니다.", HttpStatus.BAD_REQUEST),
+    CHATROOM_INVALID_MEMBER(1003, "유효하지 않은 회원은 채팅방에 포함될 수 없습니다.", HttpStatus.BAD_REQUEST),
 
     // 유효성 검사 실패
     VALIDATION_FAILED(40000, "유효하지 않은 입력입니다.", HttpStatus.BAD_REQUEST),

--- a/communication-service/src/main/java/com/example/communicationservice/common/status/ResponseDtoStatus.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/status/ResponseDtoStatus.java
@@ -15,7 +15,16 @@ public enum ResponseDtoStatus {
     CHATROOM_ALREADY_EXISTS(1002, "이미 채팅방이 존재합니다.", HttpStatus.BAD_REQUEST),
 
     // 유효성 검사 실패
-    VALIDATION_FAILED(40000, "유효하지 않은 입력입니다.", HttpStatus.BAD_REQUEST);
+    VALIDATION_FAILED(40000, "유효하지 않은 입력입니다.", HttpStatus.BAD_REQUEST),
+
+    // Feign 통신 실패
+    FEIGN_COMMUNICATION_ERROR(50000, "내부 서비스 통신 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY),
+    FEIGN_BAD_REQUEST(50001, "내부 서비스로 잘못된 요청이 전달되었습니다.", HttpStatus.BAD_REQUEST),
+    FEIGN_UNAUTHORIZED(50002, "내부 서비스 인증에 실패했습니다.", HttpStatus.UNAUTHORIZED),
+    FEIGN_FORBIDDEN(50003, "내부 서비스 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    FEIGN_NOT_FOUND(50004, "내부 서비스에서 요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FEIGN_INTERNAL_SERVER_ERROR(50005, "내부 서비스에서 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    FEIGN_UNKNOWN_ERROR(50006, "내부 서비스와의 통신 중 알 수 없는 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final int code;
     private final String message;

--- a/communication-service/src/main/java/com/example/communicationservice/common/status/ResponseDtoStatus.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/status/ResponseDtoStatus.java
@@ -1,0 +1,22 @@
+package com.example.communicationservice.common.status;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ResponseDtoStatus {
+
+    // 요청 성공
+    SUCCESS(0, "요청이 성공하였습니다.", HttpStatus.OK);
+
+    private final int code;
+    private final String message;
+    private final int httpStatusCode;
+
+    ResponseDtoStatus(int code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatusCode = httpStatus.value();
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/common/status/ResponseDtoStatus.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/status/ResponseDtoStatus.java
@@ -7,7 +7,15 @@ import org.springframework.http.HttpStatus;
 public enum ResponseDtoStatus {
 
     // 요청 성공
-    SUCCESS(0, "요청이 성공하였습니다.", HttpStatus.OK);
+    SUCCESS(0, "요청이 성공하였습니다.", HttpStatus.OK),
+
+    // 채팅방 관련 실패
+    CHATROOM_INVALID_MEMBER_COUNT(1000, "1:1 채팅은 2명의 참여자가 필요합니다.", HttpStatus.BAD_REQUEST),
+    CHATROOM_NOT_INCLUDE_SELF(1001, "현재 로그인한 사용자는 채팅방에 포함되어야 합니다.", HttpStatus.BAD_REQUEST),
+    CHATROOM_ALREADY_EXISTS(1002, "이미 채팅방이 존재합니다.", HttpStatus.BAD_REQUEST),
+
+    // 유효성 검사 실패
+    VALIDATION_FAILED(40000, "유효하지 않은 입력입니다.", HttpStatus.BAD_REQUEST);
 
     private final int code;
     private final String message;

--- a/communication-service/src/main/java/com/example/communicationservice/config/MongoDbConfiguration.java
+++ b/communication-service/src/main/java/com/example/communicationservice/config/MongoDbConfiguration.java
@@ -1,0 +1,9 @@
+package com.example.communicationservice.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+
+@Configuration
+@EnableMongoAuditing
+public class MongoDbConfiguration {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/config/SwaggerConfig.java
+++ b/communication-service/src/main/java/com/example/communicationservice/config/SwaggerConfig.java
@@ -1,0 +1,20 @@
+package com.example.communicationservice.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("Communication Service API")
+                .description("채팅방 및 메시지 관리 서비스 API 명세서")
+            );
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/ChatRoomController.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/ChatRoomController.java
@@ -1,0 +1,36 @@
+package com.example.communicationservice.controller;
+
+import com.example.communicationservice.common.response.ResponseDto;
+import com.example.communicationservice.controller.dto.request.ChatRoomCreateRequest;
+import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
+import com.example.communicationservice.service.ChatRoomService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chatrooms")
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    // 채팅방 생성 API
+    @PostMapping
+    public ResponseEntity<ResponseDto<ChatRoomCreateResponse>> createRoom(
+        @Valid @RequestBody ChatRoomCreateRequest request,
+        @RequestHeader(name = "X-CODE") String currentMemberCode
+    ) {
+        ChatRoomCreateResponse response = chatRoomService.createChatRoom(
+            request.name(), request.memberCodes(),
+            currentMemberCode
+        );
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ResponseDto.success(response));
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/ChatRoomController.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/ChatRoomController.java
@@ -1,6 +1,7 @@
 package com.example.communicationservice.controller;
 
 import com.example.communicationservice.common.response.ResponseDto;
+import com.example.communicationservice.controller.api.ChatRoomControllerApi;
 import com.example.communicationservice.controller.dto.request.ChatRoomCreateRequest;
 import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
 import com.example.communicationservice.service.ChatRoomService;
@@ -13,12 +14,13 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chatrooms")
-public class ChatRoomController {
+public class ChatRoomController implements ChatRoomControllerApi {
 
     private final ChatRoomService chatRoomService;
 
     // 채팅방 생성 API
     @PostMapping
+    @Override
     public ResponseEntity<ResponseDto<ChatRoomCreateResponse>> createRoom(
         @Valid @RequestBody ChatRoomCreateRequest request,
         @RequestHeader(name = "X-CODE") String currentMemberCode

--- a/communication-service/src/main/java/com/example/communicationservice/controller/api/ChatRoomControllerApi.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/api/ChatRoomControllerApi.java
@@ -5,38 +5,39 @@ import com.example.communicationservice.controller.dto.request.ChatRoomCreateReq
 import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "ChatRoom API", description = "채팅방 CRUD")
 public interface ChatRoomControllerApi {
 
     @Operation(
         summary = "채팅방 생성",
-        description = "새로운 채팅방을 생성합니다.",
-        responses = {
-            @ApiResponse(
-                responseCode = "201",
-                description = "채팅방 생성 성공",
-                content = @Content(schema = @Schema(implementation = ChatRoomCreateResponse.class))
-            ),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청")
-        }
+        description = "채팅방 이름과 참여할 회원 코드 목록으로 새로운 채팅방을 생성합니다."
     )
-    @PostMapping
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "채팅방 생성 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
     ResponseEntity<ResponseDto<ChatRoomCreateResponse>> createRoom(
-        @Parameter(description = "채팅방 생성 요청 DTO", required = true)
-        @Valid @RequestBody ChatRoomCreateRequest request,
+        @RequestBody(
+            description = "채팅방 생성 요청 DTO",
+            required = true
+        )
+        ChatRoomCreateRequest request,
 
-        @Parameter(hidden = true)
-        @RequestHeader(name = "X-CODE", required = false) String currentMemberCode
+        @Parameter(
+            name = "X-CODE",
+            description = "현재 로그인한 회원 코드",
+            required = true,
+            in = ParameterIn.HEADER,
+            example = "abc-12345-ABC"
+        )
+        String currentMemberCode
     );
 
 }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/api/ChatRoomControllerApi.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/api/ChatRoomControllerApi.java
@@ -1,0 +1,42 @@
+package com.example.communicationservice.controller.api;
+
+import com.example.communicationservice.common.response.ResponseDto;
+import com.example.communicationservice.controller.dto.request.ChatRoomCreateRequest;
+import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "ChatRoom API", description = "채팅방 CRUD")
+public interface ChatRoomControllerApi {
+
+    @Operation(
+        summary = "채팅방 생성",
+        description = "새로운 채팅방을 생성합니다.",
+        responses = {
+            @ApiResponse(
+                responseCode = "201",
+                description = "채팅방 생성 성공",
+                content = @Content(schema = @Schema(implementation = ChatRoomCreateResponse.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+        }
+    )
+    @PostMapping
+    ResponseEntity<ResponseDto<ChatRoomCreateResponse>> createRoom(
+        @Parameter(description = "채팅방 생성 요청 DTO", required = true)
+        @Valid @RequestBody ChatRoomCreateRequest request,
+
+        @Parameter(hidden = true)
+        @RequestHeader(name = "X-CODE", required = false) String currentMemberCode
+    );
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatRoomCreateRequest.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatRoomCreateRequest.java
@@ -1,0 +1,19 @@
+package com.example.communicationservice.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record ChatRoomCreateRequest(
+
+    @NotBlank(message = "채팅방 이름은 필수입니다.")
+    @Size(max = 50, message = "채팅방 이름은 최대 50자까지 가능합니다.")
+    String name,
+
+    @NotNull(message = "참여자 목록은 필수입니다.")
+    List<@NotBlank(message = "참여자 코드는 비어 있을 수 없습니다.") String> memberCodes
+
+) {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatRoomCreateResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatRoomCreateResponse.java
@@ -1,0 +1,11 @@
+package com.example.communicationservice.controller.dto.response;
+
+import com.example.communicationservice.entity.ChatRoom;
+
+public record ChatRoomCreateResponse(
+    String id
+) {
+    public static ChatRoomCreateResponse from(ChatRoom chatRoom) {
+        return new ChatRoomCreateResponse(chatRoom.getId());
+    }
+}

--- a/communication-service/src/main/java/com/example/communicationservice/entity/ChatRoom.java
+++ b/communication-service/src/main/java/com/example/communicationservice/entity/ChatRoom.java
@@ -31,7 +31,7 @@ public class ChatRoom {
     private Instant updatedAt;
 
     @Builder
-    public ChatRoom(String name, List<String> memberCodes) {
+    private ChatRoom(String name, List<String> memberCodes) {
         this.name = name;
         this.memberCodes = memberCodes;
     }

--- a/communication-service/src/main/java/com/example/communicationservice/entity/ChatRoom.java
+++ b/communication-service/src/main/java/com/example/communicationservice/entity/ChatRoom.java
@@ -1,0 +1,39 @@
+package com.example.communicationservice.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Document(collection = "chat_rooms")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom {
+
+    @Id
+    private String id; // MongoDB의 PK, ObjectId와 매핑
+
+    private String name;
+
+    private List<String> memberCodes;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public ChatRoom(String name, List<String> memberCodes) {
+        this.name = name;
+        this.memberCodes = memberCodes;
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/entity/ChatRoom.java
+++ b/communication-service/src/main/java/com/example/communicationservice/entity/ChatRoom.java
@@ -9,7 +9,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @Getter
@@ -25,10 +25,10 @@ public class ChatRoom {
     private List<String> memberCodes;
 
     @CreatedDate
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     @Builder
     public ChatRoom(String name, List<String> memberCodes) {

--- a/communication-service/src/main/java/com/example/communicationservice/repository/ChatRoomRepository.java
+++ b/communication-service/src/main/java/com/example/communicationservice/repository/ChatRoomRepository.java
@@ -1,0 +1,12 @@
+package com.example.communicationservice.repository;
+
+import com.example.communicationservice.entity.ChatRoom;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+public interface ChatRoomRepository extends MongoRepository<ChatRoom, String> {
+
+    @Query("{ 'memberCodes': { $all: [?0, ?1] } }")
+    boolean existsByMemberCodes(String memberCode1, String memberCode2);
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/repository/ChatRoomRepository.java
+++ b/communication-service/src/main/java/com/example/communicationservice/repository/ChatRoomRepository.java
@@ -4,9 +4,11 @@ import com.example.communicationservice.entity.ChatRoom;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
+import java.util.List;
+
 public interface ChatRoomRepository extends MongoRepository<ChatRoom, String> {
 
-    @Query("{ 'memberCodes': { $all: [?0, ?1] } }")
-    boolean existsByMemberCodes(String memberCode1, String memberCode2);
+    @Query("{ 'memberCodes': { $all: ?0, $size: ?1 } }")
+    boolean existsByMemberCodes(List<String> memberCodes, int size);
 
 }

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
@@ -7,7 +7,6 @@ import com.example.communicationservice.entity.ChatRoom;
 import com.example.communicationservice.repository.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -24,7 +23,6 @@ public class ChatRoomService {
      * @param currentMemberCode 현재 로그인한 회원의 코드
      * @return 생성된 채팅방 아이디
      */
-    @Transactional
     public ChatRoomCreateResponse createChatRoom(String name, List<String> memberCodes, String currentMemberCode) {
         // 1:1 채팅인지 확인
         if (memberCodes.stream().distinct().count() != 2) {

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
@@ -1,0 +1,58 @@
+package com.example.communicationservice.service;
+
+import com.example.communicationservice.common.exception.ChatRoomException;
+import com.example.communicationservice.common.status.ResponseDtoStatus;
+import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
+import com.example.communicationservice.entity.ChatRoom;
+import com.example.communicationservice.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    /**
+     * 새로운 채팅방을 생성하고 저장합니다.
+     * @param name 채팅방 이름
+     * @param memberCodes 채팅방 참여자들의 코드 목록
+     * @param currentMemberCode 현재 로그인한 회원의 코드
+     * @return 생성된 채팅방 아이디
+     */
+    @Transactional
+    public ChatRoomCreateResponse createChatRoom(String name, List<String> memberCodes, String currentMemberCode) {
+        // 1:1 채팅인지 확인
+        if (memberCodes.size() != 2) {
+            throw new ChatRoomException(ResponseDtoStatus.CHATROOM_INVALID_MEMBER_COUNT);
+        }
+
+        // 현재 로그인한 회원이 채팅방에 포함되어 있는지 확인
+        if (!memberCodes.contains(currentMemberCode)) {
+            throw new ChatRoomException(ResponseDtoStatus.CHATROOM_NOT_INCLUDE_SELF);
+        }
+
+        // 이미 생성된 채팅방이 있는지 확인
+        if (chatRoomRepository.existsByMemberCodes(memberCodes.get(0), memberCodes.get(1))) {
+            throw new ChatRoomException(ResponseDtoStatus.CHATROOM_ALREADY_EXISTS);
+        }
+
+        // TODO: memberCodes의 모든 회원 코드가 유효한지 확인
+
+        // 채팅방 생성
+        ChatRoom chatRoom = ChatRoom.builder()
+            .name(name)
+            .memberCodes(memberCodes)
+            .build();
+
+        // 채팅방 저장 후 반환
+        ChatRoom createdChatRoom = chatRoomRepository.save(chatRoom);
+
+        return ChatRoomCreateResponse.from(createdChatRoom);
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
@@ -1,5 +1,7 @@
 package com.example.communicationservice.service;
 
+import com.example.communicationservice.client.MemberServiceClient;
+import com.example.communicationservice.client.dto.MemberExistOutput;
 import com.example.communicationservice.common.exception.ChatRoomException;
 import com.example.communicationservice.common.status.ResponseDtoStatus;
 import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
@@ -15,6 +17,7 @@ import java.util.List;
 public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final MemberServiceClient memberServiceClient;
 
     /**
      * 새로운 채팅방을 생성하고 저장합니다.
@@ -34,12 +37,17 @@ public class ChatRoomService {
             throw new ChatRoomException(ResponseDtoStatus.CHATROOM_NOT_INCLUDE_SELF);
         }
 
+        MemberExistOutput result = memberServiceClient.getMemberExistences(memberCodes).getData();
+
+        // memberCodes의 모든 참여자 코드가 유효한지 확인
+        if (!result.notExists().isEmpty()) {
+            throw new ChatRoomException(ResponseDtoStatus.CHATROOM_INVALID_MEMBER);
+        }
+
         // 이미 생성된 채팅방이 있는지 확인
         if (chatRoomRepository.existsByMemberCodes(memberCodes, memberCodes.size())) {
             throw new ChatRoomException(ResponseDtoStatus.CHATROOM_ALREADY_EXISTS);
         }
-
-        // TODO: memberCodes의 모든 회원 코드가 유효한지 확인
 
         // 채팅방 생성
         ChatRoom chatRoom = ChatRoom.builder()

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
@@ -27,7 +27,7 @@ public class ChatRoomService {
     @Transactional
     public ChatRoomCreateResponse createChatRoom(String name, List<String> memberCodes, String currentMemberCode) {
         // 1:1 채팅인지 확인
-        if (memberCodes.size() != 2) {
+        if (memberCodes.stream().distinct().count() != 2) {
             throw new ChatRoomException(ResponseDtoStatus.CHATROOM_INVALID_MEMBER_COUNT);
         }
 

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
@@ -31,7 +31,7 @@ public class ChatRoomService {
             throw new ChatRoomException(ResponseDtoStatus.CHATROOM_INVALID_MEMBER_COUNT);
         }
 
-        // 현재 로그인한 회원이 채팅방에 포함되어 있는지 확인
+        // 현재 로그인한 회원이 참여자 코드 목록에 포함되어 있는지 확인
         if (!memberCodes.contains(currentMemberCode)) {
             throw new ChatRoomException(ResponseDtoStatus.CHATROOM_NOT_INCLUDE_SELF);
         }
@@ -49,7 +49,7 @@ public class ChatRoomService {
             .memberCodes(memberCodes)
             .build();
 
-        // 채팅방 저장 후 반환
+        // 채팅방 저장
         ChatRoom createdChatRoom = chatRoomRepository.save(chatRoom);
 
         return ChatRoomCreateResponse.from(createdChatRoom);

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
@@ -37,7 +37,7 @@ public class ChatRoomService {
         }
 
         // 이미 생성된 채팅방이 있는지 확인
-        if (chatRoomRepository.existsByMemberCodes(memberCodes.get(0), memberCodes.get(1))) {
+        if (chatRoomRepository.existsByMemberCodes(memberCodes, memberCodes.size())) {
             throw new ChatRoomException(ResponseDtoStatus.CHATROOM_ALREADY_EXISTS);
         }
 

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatRoomServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatRoomServiceTest.java
@@ -1,0 +1,143 @@
+package com.example.communicationservice.service;
+
+import com.example.communicationservice.client.MemberServiceClient;
+import com.example.communicationservice.client.dto.MemberExistOutput;
+import com.example.communicationservice.common.exception.ChatRoomException;
+import com.example.communicationservice.common.response.ResponseDto;
+import com.example.communicationservice.common.status.ResponseDtoStatus;
+import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
+import com.example.communicationservice.entity.ChatRoom;
+import com.example.communicationservice.repository.ChatRoomRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomServiceTest {
+
+    @InjectMocks
+    private ChatRoomService chatRoomService;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private MemberServiceClient memberServiceClient;
+
+    @Test
+    void 채팅방_생성에_성공한다() {
+        // given
+        String roomName = "채팅방";
+        String myCode = "USER_A";
+        String partnerCode = "USER_B";
+        String roomId = "generated-mongodb-id-123";
+        List<String> memberCodes = List.of(myCode, partnerCode);
+
+        MemberExistOutput mockOutput = new MemberExistOutput(memberCodes, List.of());
+
+        given(memberServiceClient.getMemberExistences(anyList()))
+            .willReturn(ResponseDto.success(mockOutput));
+
+        given(chatRoomRepository.existsByMemberCodes(anyList(), anyInt()))
+            .willReturn(false);
+
+        ChatRoom savedChatRoom = ChatRoom.builder()
+            .name(roomName)
+            .memberCodes(memberCodes)
+            .build();
+
+        ReflectionTestUtils.setField(savedChatRoom, "id", roomId); // 리플렉션으로 아이디 추가
+
+        given(chatRoomRepository.save(any(ChatRoom.class)))
+            .willReturn(savedChatRoom);
+
+        // when
+        ChatRoomCreateResponse response = chatRoomService.createChatRoom(roomName, memberCodes, myCode);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(roomId);
+
+        verify(chatRoomRepository, times(1)).save(any(ChatRoom.class));
+    }
+
+    @Test
+    void 채팅방_참여자_수가_2명이_아니면_채팅방_생성에_실패한다() {
+        // given
+        String myCode = "USER_A";
+        List<String> memberCodes = List.of(myCode);
+
+        // when & then
+        ChatRoomException exception = assertThrows(ChatRoomException.class,
+            () -> chatRoomService.createChatRoom("채팅방", memberCodes, myCode));
+
+        assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_INVALID_MEMBER_COUNT);
+    }
+
+    @Test
+    void 채팅방_생성_요청자가_채팅방_참여자_목록에_없으면_채팅방_생성에_실패한다() {
+        // given
+        String myCode = "USER_A";
+        List<String> memberCodes = List.of("USER_B", "USER_C");
+
+        // when & then
+        ChatRoomException exception = assertThrows(ChatRoomException.class,
+            () -> chatRoomService.createChatRoom("채팅방", memberCodes, myCode));
+
+        assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_NOT_INCLUDE_SELF);
+    }
+
+    @Test
+    @DisplayName("실패 - 존재하지 않는 회원이 포함됨")
+    void 채팅방_참여자_목록에_유효하지_않은_회원이_있으면_채팅방_생성에_실패한다() {
+        // given
+        String myCode = "USER_A";
+        String unknownCode = "USER_UNKNOWN";
+        List<String> memberCodes = List.of(myCode, unknownCode);
+
+        MemberExistOutput mockOutput = new MemberExistOutput(List.of(myCode), List.of(unknownCode));
+
+        given(memberServiceClient.getMemberExistences(anyList()))
+            .willReturn(ResponseDto.success(mockOutput));
+
+        // when & then
+        ChatRoomException exception = assertThrows(ChatRoomException.class,
+            () -> chatRoomService.createChatRoom("채팅방", memberCodes, myCode));
+
+        assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_INVALID_MEMBER);
+    }
+
+    @Test
+    void 채팅방_참여자_사이에_이미_채팅방이_존재하면_채팅방_생성에_실패한다() {
+        // given
+        List<String> memberCodes = List.of("USER_A", "USER_B");
+
+        MemberExistOutput mockOutput = new MemberExistOutput(memberCodes, List.of());
+
+        given(memberServiceClient.getMemberExistences(anyList()))
+            .willReturn(ResponseDto.success(mockOutput));
+
+        given(chatRoomRepository.existsByMemberCodes(anyList(), anyInt()))
+            .willReturn(true);
+
+        // when & then
+        ChatRoomException exception = assertThrows(ChatRoomException.class,
+            () -> chatRoomService.createChatRoom("채팅방", memberCodes, "USER_A"));
+
+        assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_ALREADY_EXISTS);
+    }
+
+}


### PR DESCRIPTION
## 📌 목적
- 채팅방 생성 기능을 구현합니다.

## ✅ 변경 사항
### 추가된 의존성
- validation
- swagger
- mongodb

### 요청 흐름
```mermaid
sequenceDiagram
    participant Client
    participant Gateway
    participant ChatRoomController
    participant ChatRoomService
    participant MongoDB

    Client->>Gateway: POST /api/chatrooms<br> Body: { name, memberCodes }
    Gateway->>ChatRoomController: 전달 + X-CODE 헤더 삽입
    ChatRoomController->>ChatRoomService: createChatRoom(name, memberCodes, currentMemberCode)
    ChatRoomService->>MongoDB: insert ChatRoom document
    MongoDB-->>ChatRoomService: 저장된 ChatRoom 반환
    ChatRoomService-->>ChatRoomController: ChatRoomCreateResponse 반환
    ChatRoomController-->>Gateway: ResponseDto<ChatRoomCreateResponse> (201 CREATED)
    Gateway-->>Client: 최종 응답 전달

```

## 🧪 테스트 방법
- 서비스 단위 테스트인 ChatRoomServiceTest를 실행합니다.

## 📎 참고 사항
- 계층 구조를 반영하여 엔드포인트를 `/api/chats/`에서 `/api/chatrooms/`로 변경했습니다.

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [x] 코드 컨벤션을 모두 지켰나요?
- [x] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
