### PR TITLE
feat(chat): 채팅방 조회 기능 구현

### DIFF
--- a/communication-service/src/main/java/com/example/communicationservice/common/exception/GlobalExceptionHandler.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/exception/GlobalExceptionHandler.java
@@ -28,7 +28,7 @@ public class GlobalExceptionHandler {
 
     // 커스텀 예외 처리
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ResponseDto<Empty>> handleChatRoomException(CustomException ex) {
+    public ResponseEntity<ResponseDto<Empty>> handleCustomException(CustomException ex) {
         ResponseDtoStatus status = ex.getStatus();
 
         return ResponseEntity

--- a/communication-service/src/main/java/com/example/communicationservice/common/status/ResponseDtoStatus.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/status/ResponseDtoStatus.java
@@ -14,6 +14,8 @@ public enum ResponseDtoStatus {
     CHATROOM_NOT_INCLUDE_SELF(1001, "현재 로그인한 사용자는 채팅방에 포함되어야 합니다.", HttpStatus.BAD_REQUEST),
     CHATROOM_ALREADY_EXISTS(1002, "이미 채팅방이 존재합니다.", HttpStatus.BAD_REQUEST),
     CHATROOM_INVALID_MEMBER(1003, "유효하지 않은 회원은 채팅방에 포함될 수 없습니다.", HttpStatus.BAD_REQUEST),
+    CHATROOM_NOT_FOUND(1004, "채팅방이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    CHATROOM_UNAUTHORIZED(1005, "해당 채팅방에 접근할 권한이 없습니다.", HttpStatus.UNAUTHORIZED),
 
     // 유효성 검사 실패
     VALIDATION_FAILED(40000, "유효하지 않은 입력입니다.", HttpStatus.BAD_REQUEST),

--- a/communication-service/src/main/java/com/example/communicationservice/controller/ChatRoomController.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/ChatRoomController.java
@@ -4,9 +4,13 @@ import com.example.communicationservice.common.response.ResponseDto;
 import com.example.communicationservice.controller.api.ChatRoomControllerApi;
 import com.example.communicationservice.controller.dto.request.ChatRoomCreateRequest;
 import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
+import com.example.communicationservice.controller.dto.response.ChatRoomListReadResponse;
 import com.example.communicationservice.service.ChatRoomService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -32,6 +36,24 @@ public class ChatRoomController implements ChatRoomControllerApi {
 
         return ResponseEntity
             .status(HttpStatus.CREATED)
+            .body(ResponseDto.success(response));
+    }
+
+    // 채팅방 목록 조회 API
+    @GetMapping
+    public ResponseEntity<ResponseDto<ChatRoomListReadResponse>> findRooms(
+        @PageableDefault(
+            size = 10,
+            sort = "updatedAt",
+            direction = Sort.Direction.DESC
+        )
+        Pageable pageable,
+        @RequestHeader(name = "X-CODE") String currentMemberCode
+    ) {
+        ChatRoomListReadResponse response = chatRoomService.findAllChatRooms(currentMemberCode, pageable);
+
+        return ResponseEntity
+            .ok()
             .body(ResponseDto.success(response));
     }
 

--- a/communication-service/src/main/java/com/example/communicationservice/controller/ChatRoomController.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/ChatRoomController.java
@@ -41,6 +41,7 @@ public class ChatRoomController implements ChatRoomControllerApi {
 
     // 채팅방 목록 조회 API
     @GetMapping
+    @Override
     public ResponseEntity<ResponseDto<ChatRoomListReadResponse>> findRooms(
         @PageableDefault(
             size = 10,

--- a/communication-service/src/main/java/com/example/communicationservice/controller/ChatRoomController.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/ChatRoomController.java
@@ -3,8 +3,10 @@ package com.example.communicationservice.controller;
 import com.example.communicationservice.common.response.ResponseDto;
 import com.example.communicationservice.controller.api.ChatRoomControllerApi;
 import com.example.communicationservice.controller.dto.request.ChatRoomCreateRequest;
+import com.example.communicationservice.controller.dto.response.ChatMessageListReadResponse;
 import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
 import com.example.communicationservice.controller.dto.response.ChatRoomListReadResponse;
+import com.example.communicationservice.service.ChatMessageService;
 import com.example.communicationservice.service.ChatRoomService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class ChatRoomController implements ChatRoomControllerApi {
 
     private final ChatRoomService chatRoomService;
+    private final ChatMessageService chatMessageService;
 
     // 채팅방 생성 API
     @PostMapping
@@ -52,6 +55,25 @@ public class ChatRoomController implements ChatRoomControllerApi {
         @RequestHeader(name = "X-CODE") String currentMemberCode
     ) {
         ChatRoomListReadResponse response = chatRoomService.findAllChatRooms(currentMemberCode, pageable);
+
+        return ResponseEntity
+            .ok()
+            .body(ResponseDto.success(response));
+    }
+
+    // 채팅방 메시지 목록 조회 API
+    @GetMapping("/{room-id}/messages")
+    public ResponseEntity<ResponseDto<ChatMessageListReadResponse>> findMessages(
+        @PathVariable(name = "room-id") String roomId,
+        @RequestHeader(name = "X-CODE") String currentMemberCode,
+        @PageableDefault(
+            size = 50,
+            sort = "sentAt",
+            direction = Sort.Direction.ASC
+        )
+        Pageable pageable
+    ) {
+        ChatMessageListReadResponse response = chatMessageService.findMessagesByRoomId(roomId, currentMemberCode, pageable);
 
         return ResponseEntity
             .ok()

--- a/communication-service/src/main/java/com/example/communicationservice/controller/ChatRoomController.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/ChatRoomController.java
@@ -63,6 +63,7 @@ public class ChatRoomController implements ChatRoomControllerApi {
 
     // 채팅방 메시지 목록 조회 API
     @GetMapping("/{room-id}/messages")
+    @Override
     public ResponseEntity<ResponseDto<ChatMessageListReadResponse>> findMessages(
         @PathVariable(name = "room-id") String roomId,
         @RequestHeader(name = "X-CODE") String currentMemberCode,

--- a/communication-service/src/main/java/com/example/communicationservice/controller/api/ChatRoomControllerApi.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/api/ChatRoomControllerApi.java
@@ -3,6 +3,7 @@ package com.example.communicationservice.controller.api;
 import com.example.communicationservice.common.response.ResponseDto;
 import com.example.communicationservice.controller.dto.request.ChatRoomCreateRequest;
 import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
+import com.example.communicationservice.controller.dto.response.ChatRoomListReadResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -10,6 +11,10 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "ChatRoom API", description = "채팅방 CRUD")
@@ -29,6 +34,33 @@ public interface ChatRoomControllerApi {
             required = true
         )
         ChatRoomCreateRequest request,
+
+        @Parameter(
+            name = "X-CODE",
+            description = "현재 로그인한 회원 코드",
+            required = true,
+            in = ParameterIn.HEADER,
+            example = "abc-12345-ABC"
+        )
+        String currentMemberCode
+    );
+
+    @Operation(
+        summary = "채팅방 목록 조회",
+        description = "현재 로그인한 회원이 참여하는 채팅방 목록을 최신순으로 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "채팅방 목록 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    ResponseEntity<ResponseDto<ChatRoomListReadResponse>> findRooms(
+        @ParameterObject
+        @PageableDefault(
+            size = 10,
+            sort = "updatedAt",
+            direction = Sort.Direction.DESC
+        )
+        Pageable pageable,
 
         @Parameter(
             name = "X-CODE",

--- a/communication-service/src/main/java/com/example/communicationservice/controller/api/ChatRoomControllerApi.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/api/ChatRoomControllerApi.java
@@ -2,6 +2,7 @@ package com.example.communicationservice.controller.api;
 
 import com.example.communicationservice.common.response.ResponseDto;
 import com.example.communicationservice.controller.dto.request.ChatRoomCreateRequest;
+import com.example.communicationservice.controller.dto.response.ChatMessageListReadResponse;
 import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
 import com.example.communicationservice.controller.dto.response.ChatRoomListReadResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -70,6 +71,42 @@ public interface ChatRoomControllerApi {
             example = "abc-12345-ABC"
         )
         String currentMemberCode
+    );
+
+    @Operation(
+        summary = "채팅방 메시지 목록 조회",
+        description = "채팅방 아이디로 채팅 메시지들을 오래된 순으로 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "채팅방 메시지 목록 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    ResponseEntity<ResponseDto<ChatMessageListReadResponse>> findMessages(
+        @Parameter(
+            name = "room-id",
+            description = "채팅방 아이디",
+            required = true,
+            in = ParameterIn.PATH,
+            example = "651f7c8b9a1d4c6f8b2e3d1a"
+        )
+        String roomId,
+
+        @Parameter(
+            name = "X-CODE",
+            description = "현재 로그인한 회원 코드",
+            required = true,
+            in = ParameterIn.HEADER,
+            example = "abc-12345-ABC"
+        )
+        String currentMemberCode,
+
+        @ParameterObject
+        @PageableDefault(
+            size = 50,
+            sort = "sentAt",
+            direction = Sort.Direction.ASC
+        )
+        Pageable pageable
     );
 
 }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageListReadResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageListReadResponse.java
@@ -1,0 +1,9 @@
+package com.example.communicationservice.controller.dto.response;
+
+import java.util.List;
+
+public record ChatMessageListReadResponse(
+    List<ChatMessageReadResponse> messages,
+    PageInfo pageInfo
+) {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageReadResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageReadResponse.java
@@ -1,0 +1,11 @@
+package com.example.communicationservice.controller.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ChatMessageReadResponse(
+    String id,
+    String senderCode,
+    String content,
+    LocalDateTime sentAt
+) {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageReadResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageReadResponse.java
@@ -1,5 +1,7 @@
 package com.example.communicationservice.controller.dto.response;
 
+import com.example.communicationservice.entity.ChatMessage;
+
 import java.time.LocalDateTime;
 
 public record ChatMessageReadResponse(
@@ -8,4 +10,12 @@ public record ChatMessageReadResponse(
     String content,
     LocalDateTime sentAt
 ) {
+    public static ChatMessageReadResponse from(ChatMessage message) {
+        return new ChatMessageReadResponse(
+            message.getId(),
+            message.getSenderCode(),
+            message.getContent(),
+            message.getSentAt()
+        );
+    }
 }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageReadResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageReadResponse.java
@@ -2,13 +2,13 @@ package com.example.communicationservice.controller.dto.response;
 
 import com.example.communicationservice.entity.ChatMessage;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record ChatMessageReadResponse(
     String id,
     String senderCode,
     String content,
-    LocalDateTime sentAt
+    Instant sentAt
 ) {
     public static ChatMessageReadResponse from(ChatMessage message) {
         return new ChatMessageReadResponse(

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatRoomListReadResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatRoomListReadResponse.java
@@ -1,0 +1,9 @@
+package com.example.communicationservice.controller.dto.response;
+
+import java.util.List;
+
+public record ChatRoomListReadResponse(
+    List<ChatRoomReadResponse> chatRooms,
+    PageInfo pageInfo
+) {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatRoomReadResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatRoomReadResponse.java
@@ -2,12 +2,12 @@ package com.example.communicationservice.controller.dto.response;
 
 import com.example.communicationservice.entity.ChatRoom;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record ChatRoomReadResponse(
     String id,
     String name,
-    LocalDateTime updatedAt
+    Instant updatedAt
 ) {
     public static ChatRoomReadResponse from(ChatRoom chatRoom) {
         return new ChatRoomReadResponse(

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatRoomReadResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatRoomReadResponse.java
@@ -1,0 +1,19 @@
+package com.example.communicationservice.controller.dto.response;
+
+import com.example.communicationservice.entity.ChatRoom;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomReadResponse(
+    String id,
+    String name,
+    LocalDateTime updatedAt
+) {
+    public static ChatRoomReadResponse from(ChatRoom chatRoom) {
+        return new ChatRoomReadResponse(
+            chatRoom.getId(),
+            chatRoom.getName(),
+            chatRoom.getUpdatedAt()
+        );
+    }
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/PageInfo.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/PageInfo.java
@@ -1,0 +1,19 @@
+package com.example.communicationservice.controller.dto.response;
+
+import org.springframework.data.domain.Page;
+
+public record PageInfo(
+    int page, // 현재 페이지 번호(0-based)
+    int size, // 페이지당 항목 수
+    long totalElements, // 전체 항목 수
+    int totalPages // 전체 페이지수
+) {
+    public static PageInfo from(Page<?> page) {
+        return new PageInfo(
+            page.getNumber(),
+            page.getSize(),
+            page.getTotalElements(),
+            page.getTotalPages()
+        );
+    }
+}

--- a/communication-service/src/main/java/com/example/communicationservice/entity/ChatMessage.java
+++ b/communication-service/src/main/java/com/example/communicationservice/entity/ChatMessage.java
@@ -1,0 +1,37 @@
+package com.example.communicationservice.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Document(collection = "chat_messages")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage {
+
+    @Id
+    private String id; // MongoDB의 PK, ObjectId와 매핑
+
+    private String roomId;
+
+    private String senderCode;
+
+    private String content;
+
+    @CreatedDate
+    private LocalDateTime sentAt; // 전송된 시간
+
+    @Builder
+    public ChatMessage(String roomId, String senderCode, String content) {
+        this.roomId = roomId;
+        this.senderCode = senderCode;
+        this.content = content;
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/entity/ChatMessage.java
+++ b/communication-service/src/main/java/com/example/communicationservice/entity/ChatMessage.java
@@ -28,7 +28,7 @@ public class ChatMessage {
     private Instant sentAt; // 전송된 시간
 
     @Builder
-    public ChatMessage(String roomId, String senderCode, String content) {
+    private ChatMessage(String roomId, String senderCode, String content) {
         this.roomId = roomId;
         this.senderCode = senderCode;
         this.content = content;

--- a/communication-service/src/main/java/com/example/communicationservice/entity/ChatMessage.java
+++ b/communication-service/src/main/java/com/example/communicationservice/entity/ChatMessage.java
@@ -8,7 +8,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Document(collection = "chat_messages")
@@ -25,7 +25,7 @@ public class ChatMessage {
     private String content;
 
     @CreatedDate
-    private LocalDateTime sentAt; // 전송된 시간
+    private Instant sentAt; // 전송된 시간
 
     @Builder
     public ChatMessage(String roomId, String senderCode, String content) {

--- a/communication-service/src/main/java/com/example/communicationservice/repository/ChatMessageRepository.java
+++ b/communication-service/src/main/java/com/example/communicationservice/repository/ChatMessageRepository.java
@@ -1,0 +1,14 @@
+package com.example.communicationservice.repository;
+
+import com.example.communicationservice.entity.ChatMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
+
+    @Query("{ 'roomId' : ?0 }")
+    Page<ChatMessage> findAllByRoomId(String roomId, Pageable pageable);
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/repository/ChatRoomRepository.java
+++ b/communication-service/src/main/java/com/example/communicationservice/repository/ChatRoomRepository.java
@@ -1,6 +1,8 @@
 package com.example.communicationservice.repository;
 
 import com.example.communicationservice.entity.ChatRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
@@ -10,5 +12,8 @@ public interface ChatRoomRepository extends MongoRepository<ChatRoom, String> {
 
     @Query("{ 'memberCodes': { $all: ?0, $size: ?1 } }")
     boolean existsByMemberCodes(List<String> memberCodes, int size);
+
+    @Query("{ 'memberCodes' : ?0 }")
+    Page<ChatRoom> findAllByMemberCode(String memberCode, Pageable pageable);
 
 }

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
@@ -1,0 +1,56 @@
+package com.example.communicationservice.service;
+
+import com.example.communicationservice.common.exception.ChatRoomException;
+import com.example.communicationservice.common.status.ResponseDtoStatus;
+import com.example.communicationservice.controller.dto.response.ChatMessageListReadResponse;
+import com.example.communicationservice.controller.dto.response.ChatMessageReadResponse;
+import com.example.communicationservice.controller.dto.response.PageInfo;
+import com.example.communicationservice.entity.ChatMessage;
+import com.example.communicationservice.entity.ChatRoom;
+import com.example.communicationservice.repository.ChatMessageRepository;
+import com.example.communicationservice.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    /**
+     * 특정 채팅방의 메시지 목록을 페이징하여 조회합니다.
+     * @param roomId 조회할 채팅방 아이디
+     * @param currentMemberCode 현재 로그인한 회원의 코드
+     * @param pageable 페이징 요청 정보
+     * @return 해당 채팅방의 메시지 목록
+     */
+    public ChatMessageListReadResponse findMessagesByRoomId(String roomId, String currentMemberCode, Pageable pageable) {
+        // 해당 채팅방이 존재하는지 확인
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+            .orElseThrow(() -> new ChatRoomException(ResponseDtoStatus.CHATROOM_NOT_FOUND));
+
+        // 현재 로그인한 회원이 해당 채팅방의 참여자인지 확인
+        if (!chatRoom.getMemberCodes().contains(currentMemberCode)) {
+            throw new ChatRoomException(ResponseDtoStatus.CHATROOM_UNAUTHORIZED);
+        }
+
+        Page<ChatMessage> messagePage = chatMessageRepository.findAllByRoomId(roomId, pageable);
+
+        // 엔티티 -> DTO 변환
+        List<ChatMessageReadResponse> messages = messagePage.getContent().stream()
+            .map(ChatMessageReadResponse::from)
+            .toList();
+
+        // Page 정보 추출 및 DTO 생성
+        PageInfo pageInfo = PageInfo.from(messagePage);
+
+        return new ChatMessageListReadResponse(messages, pageInfo);
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
@@ -5,9 +5,14 @@ import com.example.communicationservice.client.dto.MemberExistOutput;
 import com.example.communicationservice.common.exception.ChatRoomException;
 import com.example.communicationservice.common.status.ResponseDtoStatus;
 import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
+import com.example.communicationservice.controller.dto.response.ChatRoomListReadResponse;
+import com.example.communicationservice.controller.dto.response.ChatRoomReadResponse;
+import com.example.communicationservice.controller.dto.response.PageInfo;
 import com.example.communicationservice.entity.ChatRoom;
 import com.example.communicationservice.repository.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -59,6 +64,26 @@ public class ChatRoomService {
         ChatRoom createdChatRoom = chatRoomRepository.save(chatRoom);
 
         return ChatRoomCreateResponse.from(createdChatRoom);
+    }
+
+    /**
+     * 채팅방 목록을 페이징하여 조회합니다.
+     * @param currentMemberCode 현재 로그인한 회원의 코드
+     * @param pageable 페이징 요청 정보
+     * @return 현재 로그인한 회원이 속한 채팅방 목록
+     */
+    public ChatRoomListReadResponse findAllChatRooms(String currentMemberCode, Pageable pageable) {
+        Page<ChatRoom> chatRoomPage = chatRoomRepository.findAllByMemberCode(currentMemberCode, pageable);
+
+        // 엔티티 -> DTO 변환
+        List<ChatRoomReadResponse> chatRooms = chatRoomPage.getContent().stream()
+            .map(ChatRoomReadResponse::from)
+            .toList();
+
+        // Page 정보 추출 및 DTO 생성
+        PageInfo pageInfo = PageInfo.from(chatRoomPage);
+
+        return new ChatRoomListReadResponse(chatRooms, pageInfo);
     }
 
 }

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
@@ -1,0 +1,147 @@
+package com.example.communicationservice.service;
+
+import com.example.communicationservice.common.exception.ChatRoomException;
+import com.example.communicationservice.common.status.ResponseDtoStatus;
+import com.example.communicationservice.controller.dto.response.ChatMessageListReadResponse;
+import com.example.communicationservice.entity.ChatMessage;
+import com.example.communicationservice.entity.ChatRoom;
+import com.example.communicationservice.repository.ChatMessageRepository;
+import com.example.communicationservice.repository.ChatRoomRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageServiceTest {
+
+    private static final String ROOM_ID = "test-room-id-123";
+    private static final String MY_CODE = "USER_A";
+    private static final String PARTNER_CODE = "USER_B";
+    private static final String ROOM_NAME = "채팅방";
+
+    @InjectMocks
+    private ChatMessageService chatMessageService;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    @Test
+    void 채팅방_메시지_목록을_페이징하여_조회한다() {
+        // given
+        ChatRoom chatRoom = createMockChatRoom(List.of(MY_CODE, PARTNER_CODE));
+        Pageable pageable = PageRequest.of(0, 10);
+
+        ChatMessage message1 = createMockMessage("안녕하세요", MY_CODE);
+        ChatMessage message2 = createMockMessage("반갑습니다", PARTNER_CODE);
+
+        List<ChatMessage> messages = List.of(message1, message2);
+
+        Page<ChatMessage> mockPage = new PageImpl<>(
+            messages,
+            pageable,
+            10L
+        );
+
+        given(chatRoomRepository.findById(eq(ROOM_ID)))
+            .willReturn(Optional.of(chatRoom));
+        given(chatMessageRepository.findAllByRoomId(eq(ROOM_ID), eq(pageable)))
+            .willReturn(mockPage);
+
+        // when
+        ChatMessageListReadResponse response = chatMessageService.findMessagesByRoomId(ROOM_ID, MY_CODE, pageable);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.messages()).hasSize(messages.size());
+        assertThat(response.messages().get(0).senderCode()).isEqualTo(MY_CODE);
+
+        assertThat(response.pageInfo().totalElements()).isEqualTo(mockPage.getTotalElements());
+        assertThat(response.pageInfo().totalPages()).isEqualTo(1);
+        assertThat(response.pageInfo().page()).isEqualTo(pageable.getPageNumber());
+
+        verify(chatRoomRepository, times(1)).findById(eq(ROOM_ID));
+        verify(chatMessageRepository, times(1)).findAllByRoomId(eq(ROOM_ID), eq(pageable));
+    }
+
+    @Test
+    void 채팅방이_존재하지_않으면_예외가_발생한다() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        given(chatRoomRepository.findById(any(String.class)))
+            .willReturn(Optional.empty());
+
+        // when & then
+        ChatRoomException exception = assertThrows(ChatRoomException.class,
+            () -> chatMessageService.findMessagesByRoomId(ROOM_ID, MY_CODE, pageable));
+
+        assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_NOT_FOUND);
+
+        verify(chatRoomRepository, times(1)).findById(eq(ROOM_ID));
+    }
+
+    @Test
+    void 현재_로그인한_회원이_채팅방_참여자가_아니면_예외가_발생한다() {
+        // given
+        ChatRoom chatRoom = createMockChatRoom(List.of(PARTNER_CODE, "USER_C")); // 참여자에 MY_CODE 없음
+        Pageable pageable = PageRequest.of(0, 10);
+
+        given(chatRoomRepository.findById(eq(ROOM_ID)))
+            .willReturn(Optional.of(chatRoom));
+
+        // when & then
+        ChatRoomException exception = assertThrows(ChatRoomException.class,
+            () -> chatMessageService.findMessagesByRoomId(ROOM_ID, MY_CODE, pageable));
+
+        assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_UNAUTHORIZED);
+
+        verify(chatMessageRepository, times(0)).findAllByRoomId(any(String.class), any(Pageable.class));
+    }
+
+    private ChatRoom createMockChatRoom(List<String> memberCodes) {
+        ChatRoom chatRoom = ChatRoom.builder()
+            .name(ROOM_NAME)
+            .memberCodes(memberCodes)
+            .build();
+
+        ReflectionTestUtils.setField(chatRoom, "id", ROOM_ID);
+
+        return chatRoom;
+    }
+
+    private ChatMessage createMockMessage(String content, String senderCode) {
+        ChatMessage message = ChatMessage.builder()
+            .roomId(ROOM_ID)
+            .senderCode(senderCode)
+            .content(content)
+            .build();
+
+        ReflectionTestUtils.setField(message, "id", "msg-" + Instant.now().getNano());
+        ReflectionTestUtils.setField(message, "sentAt", Instant.now());
+
+        return message;
+    }
+
+}

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatRoomServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatRoomServiceTest.java
@@ -6,6 +6,8 @@ import com.example.communicationservice.common.exception.ChatRoomException;
 import com.example.communicationservice.common.response.ResponseDto;
 import com.example.communicationservice.common.status.ResponseDtoStatus;
 import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
+import com.example.communicationservice.controller.dto.response.ChatRoomListReadResponse;
+import com.example.communicationservice.controller.dto.response.PageInfo;
 import com.example.communicationservice.entity.ChatRoom;
 import com.example.communicationservice.repository.ChatRoomRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -14,8 +16,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -101,7 +108,6 @@ class ChatRoomServiceTest {
     }
 
     @Test
-    @DisplayName("실패 - 존재하지 않는 회원이 포함됨")
     void 채팅방_참여자_목록에_유효하지_않은_회원이_있으면_채팅방_생성에_실패한다() {
         // given
         String myCode = "USER_A";
@@ -138,6 +144,77 @@ class ChatRoomServiceTest {
             () -> chatRoomService.createChatRoom("채팅방", memberCodes, "USER_A"));
 
         assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_ALREADY_EXISTS);
+    }
+
+    @Test
+    void 채팅방_목록을_페이징하여_조회한다() {
+        // given
+        String myCode = "USER_A";
+        Pageable pageable = PageRequest.of(0, 5); // 첫 페이지, 크기 5
+        Instant now = Instant.now();
+
+        ChatRoom room1 = ChatRoom.builder().name("채팅방1").memberCodes(List.of(myCode, "USER_B")).build();
+        ReflectionTestUtils.setField(room1, "id", "room-1");
+        ReflectionTestUtils.setField(room1, "updatedAt", now.minusSeconds(300));
+
+        ChatRoom room2 = ChatRoom.builder().name("채팅방2").memberCodes(List.of(myCode, "USER_C")).build();
+        ReflectionTestUtils.setField(room2, "id", "room-2");
+        ReflectionTestUtils.setField(room2, "updatedAt", now.minusSeconds(600));
+
+        List<ChatRoom> chatRoomList = List.of(room1, room2);
+
+        Page<ChatRoom> mockPage = new PageImpl<>(
+            chatRoomList, // 현재 페이지 컨텐츠
+            pageable,     // 요청 Pageable
+            10L           // 총 요소 개수
+        );
+
+        given(chatRoomRepository.findAllByMemberCode(eq(myCode), eq(pageable)))
+            .willReturn(mockPage);
+
+        // when
+        ChatRoomListReadResponse response = chatRoomService.findAllChatRooms(myCode, pageable);
+
+        // then
+        verify(chatRoomRepository, times(1)).findAllByMemberCode(eq(myCode), eq(pageable));
+
+        assertThat(response).isNotNull();
+        assertThat(response.chatRooms()).hasSize(chatRoomList.size());
+        assertThat(response.chatRooms().get(0).id()).isEqualTo(chatRoomList.get(0).getId());
+        assertThat(response.chatRooms().get(1).id()).isEqualTo(chatRoomList.get(1).getId());
+
+        PageInfo pageInfo = response.pageInfo();
+        assertThat(pageInfo.page()).isEqualTo(pageable.getPageNumber());
+        assertThat(pageInfo.size()).isEqualTo(pageable.getPageSize());
+        assertThat(pageInfo.totalPages()).isEqualTo(2); // (총 10개 / 페이지 크기 5)
+        assertThat(pageInfo.totalElements()).isEqualTo(mockPage.getTotalElements());
+    }
+
+    @Test
+    void 조회된_채팅방이_없을_경우_빈_목록을_반환한다() {
+        // given
+        String myCode = "USER_D";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<ChatRoom> mockEmptyPage = new PageImpl<>(
+            List.of(),  // 빈 컨텐츠
+            pageable,
+            0L          // 총 요소 개수
+        );
+
+        given(chatRoomRepository.findAllByMemberCode(anyString(), any(Pageable.class)))
+            .willReturn(mockEmptyPage);
+
+        // when
+        ChatRoomListReadResponse response = chatRoomService.findAllChatRooms(myCode, pageable);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.chatRooms()).isEmpty();
+
+        PageInfo pageInfo = response.pageInfo();
+        assertThat(pageInfo.totalPages()).isEqualTo(0);
+        assertThat(pageInfo.totalElements()).isEqualTo(mockEmptyPage.getTotalElements());
     }
 
 }


### PR DESCRIPTION
## 📌 목적
- 채팅방 목록 조회 기능을 구현합니다.
- 특정 채팅방의 메시지 목록 조회 기능을 구현합니다.

## ✅ 변경 사항
### 요청 흐름
- 채팅방 목록 조회 API
```mermaid
sequenceDiagram
    participant Client
    participant Controller as ChatRoomController
    participant Service as ChatRoomService
    participant Repo as ChatRoomRepository

    Client->>Controller: GET /api/chatrooms?page=x&size=y

    Controller->>Service: findAllChatRooms(currentMemberCode, pageable)

    Service->>Repo: findAllByMemberCode(currentMemberCode, pageable)
    Repo-->>Service: Page<ChatRoom>

    Service->>Service: 엔티티 → DTO 변환<br/>+ PageInfo 생성

    Service-->>Controller: ChatRoomListReadResponse
    Controller-->>Client: 200 OK (ChatRoomListReadResponse)
```

- 채팅방 메시지 목록 조회 API
```mermaid
sequenceDiagram
    participant Client
    participant Controller as ChatRoomController
    participant Service as ChatMessageService
    participant RoomRepo as ChatRoomRepository
    participant MsgRepo as ChatMessageRepository

    Client->>Controller: GET /api/chatrooms/{room-id}/messages?page=x&size=y

    Controller->>Service: findMessagesByRoomId(roomId, currentMemberCode, pageable)

    Service->>RoomRepo: findById(roomId)

    alt 채팅방 없음
        RoomRepo-->>Service: Optional.empty
        Service-->>Controller: ChatRoomException(NOT_FOUND)
        Controller-->>Client: 404 NOT_FOUND
    else 채팅방 존재
        RoomRepo-->>Service: ChatRoom

        alt 현재 사용자가 참여자가 아님
            Service-->>Controller: ChatRoomException(UNAUTHORIZED)
            Controller-->>Client: 403 UNAUTHORIZED
        else 권한 정상
            Service->>MsgRepo: findAllByRoomId(roomId, pageable)
            MsgRepo-->>Service: Page<ChatMessage>

            Service->>Service: 메시지 DTO 변환<br/>+ PageInfo 생성

            Service-->>Controller: ChatMessageListReadResponse
            Controller-->>Client: 200 OK (ChatMessageListReadResponse)
        end
    end

```

## 🧪 테스트 방법
- 서비스 단위 테스트인 ChatMessageServiceTest를 실행합니다.

## 📎 참고 사항
- UX를 고려하여 채팅방 메시지 목록 조회의 기본 정렬을 `오래된 순`으로 설정했습니다. 클라이언트는 마지막 페이지 번호를 사용해 제일 최신 메시지를 조회할 수 있고, 채팅방 내에서도 별도의 추가 정렬을 거칠 필요가 없습니다.
- 엔티티의 `LocalDateTime` 필드를 `Instant`로 변경했습니다.

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [x] 코드 컨벤션을 모두 지켰나요?
- [x] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
