### PR TITLE
feat(chat): 채팅 메시지 송수신 기능 구현

### DIFF
--- a/communication-service/src/main/java/com/example/communicationservice/common/status/ResponseDtoStatus.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/status/ResponseDtoStatus.java
@@ -15,7 +15,7 @@ public enum ResponseDtoStatus {
     CHATROOM_ALREADY_EXISTS(1002, "이미 채팅방이 존재합니다.", HttpStatus.BAD_REQUEST),
     CHATROOM_INVALID_MEMBER(1003, "유효하지 않은 회원은 채팅방에 포함될 수 없습니다.", HttpStatus.BAD_REQUEST),
     CHATROOM_NOT_FOUND(1004, "채팅방이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
-    CHATROOM_UNAUTHORIZED(1005, "해당 채팅방에 접근할 권한이 없습니다.", HttpStatus.UNAUTHORIZED),
+    CHATROOM_FORBIDDEN(1005, "해당 채팅방에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
     // 유효성 검사 실패
     VALIDATION_FAILED(40000, "유효하지 않은 입력입니다.", HttpStatus.BAD_REQUEST),

--- a/communication-service/src/main/java/com/example/communicationservice/config/WebSocketConfiguration.java
+++ b/communication-service/src/main/java/com/example/communicationservice/config/WebSocketConfiguration.java
@@ -20,7 +20,7 @@ public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer 
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/chat") // STOMP 클라이언트가 최초로 WebSocket handshake를 요청하는 URL
+        registry.addEndpoint("/ws/chat") // STOMP 클라이언트가 최초로 WebSocket handshake를 요청하는 URL
             .withSockJS();
     }
 

--- a/communication-service/src/main/java/com/example/communicationservice/controller/ChatMessageController.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/ChatMessageController.java
@@ -1,9 +1,16 @@
 package com.example.communicationservice.controller;
 
+import com.example.communicationservice.common.exception.ChatRoomException;
+import com.example.communicationservice.common.response.Empty;
+import com.example.communicationservice.common.response.ResponseDto;
 import com.example.communicationservice.controller.dto.request.ChatMessageSendRequest;
+import com.example.communicationservice.controller.dto.response.ChatMessageSendResponse;
+import com.example.communicationservice.service.ChatMessageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
 
 @Controller
@@ -11,11 +18,29 @@ import org.springframework.stereotype.Controller;
 public class ChatMessageController {
 
     private final SimpMessagingTemplate messagingTemplate;
+    private final ChatMessageService chatMessageService;
 
+    /**
+     * 메시지 수신 처리
+     * 1. 채팅방 참여자 인가
+     * 2. DB 저장
+     * 3. 해당 토픽 구독자에게 메시지 전송
+     */
     @MessageMapping("chat.send")
     public void handleChatMessage(ChatMessageSendRequest request) {
+        ChatMessageSendResponse response = chatMessageService.saveMessage(
+            request.roomId(), request.senderCode(), request.content()
+        );
+
         String destinationPrefix = "/queue/room/";
-        messagingTemplate.convertAndSend(destinationPrefix + request.roomId(), request);
+        messagingTemplate.convertAndSend(destinationPrefix + request.roomId(), response);
+    }
+
+    // WebSocket 전용 예외 처리
+    @MessageExceptionHandler(ChatRoomException.class)
+    @SendToUser("/queue/errors")
+    public ResponseDto<Empty> handleChatRoomException(ChatRoomException ex) {
+        return ResponseDto.error(ex.getStatus());
     }
 
 }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatMessageSendRequest.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatMessageSendRequest.java
@@ -2,7 +2,7 @@ package com.example.communicationservice.controller.dto.request;
 
 public record ChatMessageSendRequest(
     String roomId,
-    String senderId,
+    String senderCode,
     String content
 ) {
 }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageSendResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageSendResponse.java
@@ -1,0 +1,23 @@
+package com.example.communicationservice.controller.dto.response;
+
+import com.example.communicationservice.entity.ChatMessage;
+
+import java.time.LocalDateTime;
+
+public record ChatMessageSendResponse(
+    String messageId,
+    String roomId,
+    String senderCode,
+    String content,
+    LocalDateTime sentAt
+) {
+    public static ChatMessageSendResponse from(ChatMessage message) {
+        return new ChatMessageSendResponse(
+            message.getId(),
+            message.getRoomId(),
+            message.getSenderCode(),
+            message.getContent(),
+            message.getSentAt()
+        );
+    }
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageSendResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageSendResponse.java
@@ -2,14 +2,14 @@ package com.example.communicationservice.controller.dto.response;
 
 import com.example.communicationservice.entity.ChatMessage;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record ChatMessageSendResponse(
     String messageId,
     String roomId,
     String senderCode,
     String content,
-    LocalDateTime sentAt
+    Instant sentAt
 ) {
     public static ChatMessageSendResponse from(ChatMessage message) {
         return new ChatMessageSendResponse(

--- a/communication-service/src/main/java/com/example/communicationservice/entity/ChatRoom.java
+++ b/communication-service/src/main/java/com/example/communicationservice/entity/ChatRoom.java
@@ -1,9 +1,6 @@
 package com.example.communicationservice.entity;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -28,6 +25,7 @@ public class ChatRoom {
     private Instant createdAt;
 
     @LastModifiedDate
+    @Setter
     private Instant updatedAt;
 
     @Builder

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
@@ -4,6 +4,7 @@ import com.example.communicationservice.common.exception.ChatRoomException;
 import com.example.communicationservice.common.status.ResponseDtoStatus;
 import com.example.communicationservice.controller.dto.response.ChatMessageListReadResponse;
 import com.example.communicationservice.controller.dto.response.ChatMessageReadResponse;
+import com.example.communicationservice.controller.dto.response.ChatMessageSendResponse;
 import com.example.communicationservice.controller.dto.response.PageInfo;
 import com.example.communicationservice.entity.ChatMessage;
 import com.example.communicationservice.entity.ChatRoom;
@@ -13,7 +14,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -51,6 +54,39 @@ public class ChatMessageService {
         PageInfo pageInfo = PageInfo.from(messagePage);
 
         return new ChatMessageListReadResponse(messages, pageInfo);
+    }
+
+    /**
+     * 특정 채팅방의 메시지를 저장합니다.
+     * @param roomId 해당 채팅방 아이디
+     * @param senderCode 메시지 송신자 코드
+     * @param content 메시지 내용
+     * @return 수신할 메시지
+     */
+    @Transactional
+    public ChatMessageSendResponse saveMessage(String roomId, String senderCode, String content) {
+        // 해당 채팅방이 존재하는지 확인
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+            .orElseThrow(() -> new ChatRoomException(ResponseDtoStatus.CHATROOM_NOT_FOUND));
+
+        // 메시지 송신자가 해당 채팅방의 참여자인지 확인
+        if (!chatRoom.getMemberCodes().contains(senderCode)) {
+            throw new ChatRoomException(ResponseDtoStatus.CHATROOM_UNAUTHORIZED);
+        }
+
+        ChatMessage chatMessage = ChatMessage.builder()
+            .roomId(roomId)
+            .senderCode(senderCode)
+            .content(content)
+            .build();
+
+        ChatMessage savedChatMessage = chatMessageRepository.save(chatMessage);
+
+        // 채팅방의 updatedAt 갱신
+        chatRoom.setUpdatedAt(LocalDateTime.now());
+        chatRoomRepository.save(chatRoom);
+
+        return ChatMessageSendResponse.from(savedChatMessage);
     }
 
 }

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
@@ -16,7 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @Service
@@ -83,7 +83,7 @@ public class ChatMessageService {
         ChatMessage savedChatMessage = chatMessageRepository.save(chatMessage);
 
         // 채팅방의 updatedAt 갱신
-        chatRoom.setUpdatedAt(LocalDateTime.now());
+        chatRoom.setUpdatedAt(Instant.now());
         chatRoomRepository.save(chatRoom);
 
         return ChatMessageSendResponse.from(savedChatMessage);

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
@@ -40,7 +40,7 @@ public class ChatMessageService {
 
         // 현재 로그인한 회원이 해당 채팅방의 참여자인지 확인
         if (!chatRoom.getMemberCodes().contains(currentMemberCode)) {
-            throw new ChatRoomException(ResponseDtoStatus.CHATROOM_UNAUTHORIZED);
+            throw new ChatRoomException(ResponseDtoStatus.CHATROOM_FORBIDDEN);
         }
 
         Page<ChatMessage> messagePage = chatMessageRepository.findAllByRoomId(roomId, pageable);
@@ -71,7 +71,7 @@ public class ChatMessageService {
 
         // 메시지 송신자가 해당 채팅방의 참여자인지 확인
         if (!chatRoom.getMemberCodes().contains(senderCode)) {
-            throw new ChatRoomException(ResponseDtoStatus.CHATROOM_UNAUTHORIZED);
+            throw new ChatRoomException(ResponseDtoStatus.CHATROOM_FORBIDDEN);
         }
 
         ChatMessage chatMessage = ChatMessage.builder()

--- a/communication-service/src/main/resources/static/chat-test.html
+++ b/communication-service/src/main/resources/static/chat-test.html
@@ -67,7 +67,7 @@
     function connect() {
         appendMessage('Connecting...');
 
-        const socket = new SockJS('http://localhost:8080/chat');
+        const socket = new SockJS('http://localhost:8080/ws/chat');
         stompClient = Stomp.over(socket);
 
         stompClient.connect({}, function(frame) {

--- a/communication-service/src/main/resources/static/chat-test.html
+++ b/communication-service/src/main/resources/static/chat-test.html
@@ -7,14 +7,14 @@
     <style>
         #messages { border:1px solid #ccc; padding:10px; height:300px; overflow:auto; margin-bottom:10px; }
         #roomId { width:50px; }
-        #senderId { width:80px; }
+        #senderCode { width:80px; }
         #messageInput { width:200px; }
     </style>
 </head>
 <body>
 <h2>Chat Room Test</h2>
 <label>Room ID: <input type="text" id="roomId" value="950"/></label><br><br>
-<label>Sender ID: <input type="text" id="senderId" value="userA"/></label><br><br>
+<label>Sender Code: <input type="text" id="senderCode" value="userA"/></label><br><br>
 <div id="messages"></div>
 <input type="text" id="messageInput" placeholder="Type a message" />
 <button id="sendBtn">Send</button>
@@ -24,7 +24,7 @@
     let currentSubscription = null;
     const messagesDiv = document.getElementById('messages');
     const roomInput = document.getElementById('roomId');
-    const senderInput = document.getElementById('senderId');
+    const senderInput = document.getElementById('senderCode');
 
     function appendMessage(text) {
         const p = document.createElement('p');
@@ -43,13 +43,13 @@
         currentSubscription = stompClient.subscribe('/queue/room/' + roomId, function(stompMessage) {
             try {
                 const receivedMsg = JSON.parse(stompMessage.body);
-                const currentSenderId = senderInput.value;
+                const currentSenderCode = senderInput.value;
                 let displayPrefix;
 
-                if (receivedMsg.senderId === currentSenderId) {
+                if (receivedMsg.senderCode === currentSenderCode) {
                     displayPrefix = 'Me: ';
                 } else {
-                    displayPrefix = receivedMsg.senderId + ': ';
+                    displayPrefix = receivedMsg.senderCode + ': ';
                 }
 
                 appendMessage(displayPrefix + receivedMsg.content);
@@ -85,12 +85,12 @@
     document.getElementById('sendBtn').addEventListener('click', () => {
         const msg = document.getElementById('messageInput').value;
         const roomId = roomInput.value;
-        const senderId = senderInput.value;
+        const senderCode = senderInput.value;
 
         if(stompClient && stompClient.connected && msg.trim() !== '') {
             const payload = {
                 roomId: roomId,
-                senderId: senderId,
+                senderCode: senderCode,
                 content: msg
             };
 

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
@@ -3,10 +3,12 @@ package com.example.communicationservice.service;
 import com.example.communicationservice.common.exception.ChatRoomException;
 import com.example.communicationservice.common.status.ResponseDtoStatus;
 import com.example.communicationservice.controller.dto.response.ChatMessageListReadResponse;
+import com.example.communicationservice.controller.dto.response.ChatMessageSendResponse;
 import com.example.communicationservice.entity.ChatMessage;
 import com.example.communicationservice.entity.ChatRoom;
 import com.example.communicationservice.repository.ChatMessageRepository;
 import com.example.communicationservice.repository.ChatRoomRepository;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -37,6 +39,7 @@ class ChatMessageServiceTest {
     private static final String MY_CODE = "USER_A";
     private static final String PARTNER_CODE = "USER_B";
     private static final String ROOM_NAME = "채팅방";
+    private static final String CHAT_CONTENT = "테스트 메시지입니다.";
 
     @InjectMocks
     private ChatMessageService chatMessageService;
@@ -118,6 +121,73 @@ class ChatMessageServiceTest {
         assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_FORBIDDEN);
 
         verify(chatMessageRepository, times(0)).findAllByRoomId(any(String.class), any(Pageable.class));
+    }
+
+    @Test
+    void 채팅방_메시지를_저장하고_채팅방_업데이트_시간을_갱신한다() {
+        // given
+        String messageId = "saved-msg-id-1";
+        ChatRoom chatRoom = createMockChatRoom(List.of(MY_CODE, PARTNER_CODE));
+        ChatMessage savedMessage = ChatMessage.builder()
+            .roomId(ROOM_ID)
+            .senderCode(MY_CODE)
+            .content(CHAT_CONTENT)
+            .build();
+
+        ReflectionTestUtils.setField(savedMessage, "id", messageId);
+        ReflectionTestUtils.setField(savedMessage, "sentAt", Instant.now());
+
+        given(chatRoomRepository.findById(eq(ROOM_ID)))
+            .willReturn(Optional.of(chatRoom));
+        given(chatMessageRepository.save(any(ChatMessage.class)))
+            .willReturn(savedMessage);
+
+        // when
+        ChatMessageSendResponse response = chatMessageService.saveMessage(ROOM_ID, MY_CODE, CHAT_CONTENT);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.messageId()).isEqualTo(messageId);
+        assertThat(response.content()).isEqualTo(CHAT_CONTENT);
+
+        verify(chatRoomRepository, times(1)).findById(eq(ROOM_ID));
+        verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
+        verify(chatRoomRepository, times(1)).save(eq(chatRoom));
+    }
+
+    @Test
+    void 존재하지_않는_채팅방에_메시지_저장을_시도하면_예외가_발생한다() {
+        // given
+        given(chatRoomRepository.findById(any(String.class)))
+            .willReturn(Optional.empty());
+
+        // when & then
+        ChatRoomException exception = assertThrows(ChatRoomException.class,
+            () -> chatMessageService.saveMessage(ROOM_ID, MY_CODE, CHAT_CONTENT));
+
+        assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_NOT_FOUND);
+
+        verify(chatMessageRepository, times(0)).save(any());
+        verify(chatRoomRepository, times(1)).findById(eq(ROOM_ID));
+    }
+
+    @Test
+    void 메시지_송신자가_채팅방_참여자가_아니면_메시지_저장에_실패한다() {
+        // given
+        String unauthorizedUser = "UNAUTHORIZED_USER";
+        ChatRoom chatRoom = createMockChatRoom(List.of(MY_CODE, PARTNER_CODE));
+
+        given(chatRoomRepository.findById(eq(ROOM_ID)))
+            .willReturn(Optional.of(chatRoom));
+
+        // when & then
+        ChatRoomException exception = assertThrows(ChatRoomException.class,
+            () -> chatMessageService.saveMessage(ROOM_ID, unauthorizedUser, CHAT_CONTENT));
+
+        assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_FORBIDDEN);
+
+        verify(chatMessageRepository, times(0)).save(any());
+        verify(chatRoomRepository, times(0)).save(any(ChatRoom.class));
     }
 
     private ChatRoom createMockChatRoom(List<String> memberCodes) {

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
@@ -115,7 +115,7 @@ class ChatMessageServiceTest {
         ChatRoomException exception = assertThrows(ChatRoomException.class,
             () -> chatMessageService.findMessagesByRoomId(ROOM_ID, MY_CODE, pageable));
 
-        assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_UNAUTHORIZED);
+        assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_FORBIDDEN);
 
         verify(chatMessageRepository, times(0)).findAllByRoomId(any(String.class), any(Pageable.class));
     }

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
@@ -8,7 +8,6 @@ import com.example.communicationservice.entity.ChatMessage;
 import com.example.communicationservice.entity.ChatRoom;
 import com.example.communicationservice.repository.ChatMessageRepository;
 import com.example.communicationservice.repository.ChatRoomRepository;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatRoomServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatRoomServiceTest.java
@@ -10,7 +10,6 @@ import com.example.communicationservice.controller.dto.response.ChatRoomListRead
 import com.example.communicationservice.controller.dto.response.PageInfo;
 import com.example.communicationservice.entity.ChatRoom;
 import com.example.communicationservice.repository.ChatRoomRepository;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;


### PR DESCRIPTION
## 📌 목적
- 채팅 메시지를 실시간으로 주고받는 기능을 구현합니다.

## ✅ 변경 사항
- HTTP REST API와의 명확한 구분을 위해 WebSocket handshake URL을 `/chat` -> `/ws/chat`으로 변경했습니다.

## 🧪 테스트 방법
- [초기 설정](https://github.com/prgrms-be-adv-devcourse/beadv1_1_hexagon_BE/issues/12)의 테스트 방법과 동일합니다.
- 서비스 단위 테스트인 ChatMessageServiceTest를 실행합니다.

## 📎 참고 사항
- 현재 요청 바디에 메시지 송신자의 `code`를 직접 포함하고 있는데, 추후 인터셉터를 구현해 보안을 강화할 예정입니다.
- 엔티티의 `LocalDateTime` 필드를 `Instant`로 변경했습니다.

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [x] 코드 컨벤션을 모두 지켰나요?
- [x] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
