### PR TITLE
feat(contract): 계약 상태 배치 전환 로직 추가

### DIFF
--- a/contract-service/src/main/java/com/example/contractservice/common/entity/BaseEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/entity/BaseEntity.java
@@ -22,21 +22,17 @@ public class BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id; // BaseEntity
+    private Long id;
 
     @CreatedDate
     @Column(name = "created_at", nullable = false)
-    private Instant createdAt; // BaseEntity
+    private Instant createdAt;
 
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
-    private Instant updatedAt; // BaseEntity
+    private Instant updatedAt;
 
     @Column(name = "is_deleted", nullable = false)
-    private Boolean isDeleted = false; // BaseEntity
-
-    protected void touchUpdatedAt() {
-        this.updatedAt = Instant.now();
-    }
+    private Boolean isDeleted = false;
 
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/common/config/ContractJobConfig.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/common/config/ContractJobConfig.java
@@ -1,0 +1,28 @@
+package com.example.contractservice.contract.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class ContractJobConfig {
+    private final JobRepository jobRepository;
+
+    private final Step contractToDoneBatchStep;
+    private final Step contractToInProgressBatchStep;
+    private final Step contractToCancelledBatchStep;
+
+    @Bean
+    public Job statusChangeJob() {
+        return new JobBuilder("statusChangeJob", jobRepository)
+                .start(contractToDoneBatchStep)
+                .next(contractToInProgressBatchStep)
+                .next(contractToCancelledBatchStep)
+                .build();
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/common/config/ContractStepConfig.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/common/config/ContractStepConfig.java
@@ -1,0 +1,58 @@
+package com.example.contractservice.contract.common.config;
+
+import com.example.contractservice.contract.entity.ContractEntity;
+import com.example.contractservice.contract.service.batch.writer.ContractStatusWriter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class ContractStepConfig { // TODO: 실패, 에러 시 리스너 추가
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    private final ItemReader<ContractEntity> contractInProgressReader;
+    private final ItemReader<ContractEntity> contractPaidReader;
+    private final ItemReader<ContractEntity> contractConfirmedReader;
+
+    private final ContractStatusWriter contractDoneWriter;
+    private final ContractStatusWriter contractInProgressWriter;
+    private final ContractStatusWriter contractCancelledWriter;
+
+    @Value("${batch.contract.size}")
+    private int chunkSize;
+
+    @Bean
+    public Step contractToDoneBatchStep() { // IN_PROGRESS -> DONE
+        return new StepBuilder("contractToDoneBatchStep", jobRepository)
+                .<ContractEntity, ContractEntity>chunk(chunkSize, transactionManager)
+                .reader(contractInProgressReader)
+                .writer(contractDoneWriter)
+                .build();
+    }
+
+    @Bean
+    public Step contractToInProgressBatchStep() { // PAID -> IN_PROGRESS
+        return new StepBuilder("contractToInProgressBatchStep", jobRepository)
+                .<ContractEntity, ContractEntity>chunk(chunkSize, transactionManager)
+                .reader(contractPaidReader)
+                .writer(contractInProgressWriter)
+                .build();
+    }
+
+    @Bean
+    public Step contractToCancelledBatchStep() { // CONFIRMED -> CANCELLED
+        return new StepBuilder("contractToCancelledBatchStep", jobRepository)
+                .<ContractEntity, ContractEntity>chunk(chunkSize, transactionManager)
+                .reader(contractConfirmedReader)
+                .writer(contractCancelledWriter)
+                .build();
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/entity/ContractEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/entity/ContractEntity.java
@@ -82,4 +82,8 @@ public class ContractEntity extends BaseEntity {
         this.name = name;
         this.body = body;
     }
+
+    public void updateStatus(ContractStatus status) {
+        this.status = status;
+    }
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/entity/ContractEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/entity/ContractEntity.java
@@ -56,7 +56,7 @@ public class ContractEntity extends BaseEntity {
     private String body;
 
     @Builder
-    public ContractEntity(String requestorCode, String contractorCode, String freelancerCode, String code,
+    private ContractEntity(String requestorCode, String contractorCode, String freelancerCode, String code,
             Instant startedAt, Instant endedAt,
             PaymentType paymentType, Long unitAmount, ContractStatus status, String name, String body) {
         this.requestorCode = requestorCode;
@@ -81,7 +81,5 @@ public class ContractEntity extends BaseEntity {
         this.status = status;
         this.name = name;
         this.body = body;
-
-        touchUpdatedAt();
     }
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/ContractService.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/ContractService.java
@@ -25,6 +25,7 @@ import com.example.contractservice.deposit.service.DepositService;
 import com.example.contractservice.settlement.service.SettlementService;
 import com.example.contractservice.settlement.service.dto.request.SettlementSaveRequest;
 import java.net.URI;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -200,11 +201,13 @@ public class ContractService {
             throw new ContractException(INVALID_PAYMENT_MEMBER);
         }
 
-        boolean isAllConfirmed = contracts.stream().allMatch(Contract::isConfirmed);
+        boolean isAnyNotConfirmed = contracts.stream().anyMatch(contract -> !contract.isConfirmed() // CONFIRMED 상태가 아니거나
+                || contract.getInfo().startedAt().isBefore(Instant.now())); // CONFIRMED인데 현재 시간보다 프로젝트 시작일이 이전이라면(실제로는 CANCELLED 상태)
 
-        if (!isAllConfirmed) {
+        if (isAnyNotConfirmed) {
             throw new ContractException(NOT_CONFIRMED_STATUS);
         }
+
     }
 
     private void changeStatusToPay(List<Contract> contracts, List<ContractEntity> contractEntities) {

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/batch/ContractScheduledService.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/batch/ContractScheduledService.java
@@ -1,0 +1,43 @@
+package com.example.contractservice.contract.service.batch;
+
+import static java.time.ZoneOffset.UTC;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ContractScheduledService {
+
+    private final JobLauncher jobLauncher;
+    private final Job statusChangeJob;
+
+    @Scheduled(cron = "${batch.contract.interval}")
+    public void changeStatus() {
+        LocalDate curDate = Instant.now().atZone(UTC).toLocalDate(); // Instant -> LocalDate(년-월-일)
+        Instant midnight = curDate.atStartOfDay(UTC).toInstant(); // LocalDate(년-월-일) 자정 -> Instant
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("dateStr", midnight.toString())
+                .toJobParameters();
+
+        log.info("현재 날짜: {}", midnight);
+
+        try {
+            jobLauncher.run(statusChangeJob, jobParameters);
+        } catch (Exception e) {
+            log.warn("정산 배치 중 오류가 발생했습니다.", e);
+        }
+
+    }
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/batch/reader/ContractConfirmedReader.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/batch/reader/ContractConfirmedReader.java
@@ -1,0 +1,33 @@
+package com.example.contractservice.contract.service.batch.reader;
+
+import com.example.contractservice.contract.common.ContractStatus;
+import com.example.contractservice.contract.entity.ContractEntity;
+import jakarta.persistence.EntityManagerFactory;
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.database.JpaCursorItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@StepScope
+public class ContractConfirmedReader extends JpaCursorItemReader<ContractEntity> { // JpaPagingItemReader와 비교 필요
+
+    public ContractConfirmedReader(EntityManagerFactory emFactory,
+            @Value("#{jobParameters['dateStr']}") String dateStr,
+            @Value("${batch.contract.size}") int fetchSize) {
+        setEntityManagerFactory(emFactory);
+
+        setQueryString("""
+            SELECT c
+            FROM ContractEntity c
+            WHERE c.status = :status AND c.endedAt >= :time
+        """);
+
+        setHintValues(Map.of("org.hibernate.fetchSize", fetchSize));
+        Instant todayMidnight = Instant.parse(dateStr);
+
+        setParameterValues(Map.of("time", todayMidnight, "status", ContractStatus.CONFIRMED.name()));
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/batch/reader/ContractConfirmedReader.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/batch/reader/ContractConfirmedReader.java
@@ -22,12 +22,12 @@ public class ContractConfirmedReader extends JpaCursorItemReader<ContractEntity>
         setQueryString("""
             SELECT c
             FROM ContractEntity c
-            WHERE c.status = :status AND c.endedAt >= :time
+            WHERE c.status = :status AND c.startedAt <= :time
         """);
 
         setHintValues(Map.of("org.hibernate.fetchSize", fetchSize));
         Instant todayMidnight = Instant.parse(dateStr);
 
-        setParameterValues(Map.of("time", todayMidnight, "status", ContractStatus.CONFIRMED.name()));
+        setParameterValues(Map.of("time", todayMidnight, "status", ContractStatus.CONFIRMED));
     }
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/batch/reader/ContractConfirmedReader.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/batch/reader/ContractConfirmedReader.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @StepScope
-public class ContractConfirmedReader extends JpaCursorItemReader<ContractEntity> { // JpaPagingItemReader와 비교 필요
+public class ContractConfirmedReader extends JpaCursorItemReader<ContractEntity> { // TODO: 트러블슈팅 문서 보완
 
     public ContractConfirmedReader(EntityManagerFactory emFactory,
             @Value("#{jobParameters['dateStr']}") String dateStr,

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/batch/reader/ContractInProgressReader.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/batch/reader/ContractInProgressReader.java
@@ -1,0 +1,33 @@
+package com.example.contractservice.contract.service.batch.reader;
+
+import com.example.contractservice.contract.common.ContractStatus;
+import com.example.contractservice.contract.entity.ContractEntity;
+import jakarta.persistence.EntityManagerFactory;
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.database.JpaCursorItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@StepScope
+public class ContractInProgressReader extends JpaCursorItemReader<ContractEntity> { // JpaPagingItemReader와 비교 필요
+
+    public ContractInProgressReader(EntityManagerFactory emFactory,
+            @Value("#{jobParameters['dateStr']}") String dateStr,
+            @Value("${batch.contract.size}") int fetchSize) {
+        setEntityManagerFactory(emFactory);
+
+        setQueryString("""
+            SELECT c
+            FROM ContractEntity c
+            WHERE c.status = :status AND c.endedAt < :time
+        """);
+
+        setHintValues(Map.of("org.hibernate.fetchSize", fetchSize));
+        Instant todayMidnight = Instant.parse(dateStr);
+
+        setParameterValues(Map.of("time", todayMidnight, "status", ContractStatus.IN_PROGRESS.name()));
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/batch/reader/ContractInProgressReader.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/batch/reader/ContractInProgressReader.java
@@ -28,6 +28,6 @@ public class ContractInProgressReader extends JpaCursorItemReader<ContractEntity
         setHintValues(Map.of("org.hibernate.fetchSize", fetchSize));
         Instant todayMidnight = Instant.parse(dateStr);
 
-        setParameterValues(Map.of("time", todayMidnight, "status", ContractStatus.IN_PROGRESS.name()));
+        setParameterValues(Map.of("time", todayMidnight, "status", ContractStatus.IN_PROGRESS));
     }
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/batch/reader/ContractPaidReader.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/batch/reader/ContractPaidReader.java
@@ -5,11 +5,13 @@ import com.example.contractservice.contract.entity.ContractEntity;
 import jakarta.persistence.EntityManagerFactory;
 import java.time.Instant;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.database.JpaCursorItemReader;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @StepScope
 public class ContractPaidReader extends JpaCursorItemReader<ContractEntity> { // JpaPagingItemReader와 비교 필요
@@ -22,12 +24,14 @@ public class ContractPaidReader extends JpaCursorItemReader<ContractEntity> { //
         setQueryString("""
             SELECT c
             FROM ContractEntity c
-            WHERE c.status = :status AND c.endedAt >= :time
+            WHERE c.status = :status AND c.startedAt <= :time
         """);
 
         setHintValues(Map.of("org.hibernate.fetchSize", fetchSize));
         Instant todayMidnight = Instant.parse(dateStr);
 
-        setParameterValues(Map.of("time", todayMidnight, "status", ContractStatus.PAID.name()));
+        log.info("시각: {}", todayMidnight);
+
+        setParameterValues(Map.of("time", todayMidnight, "status", ContractStatus.PAID));
     }
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/batch/reader/ContractPaidReader.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/batch/reader/ContractPaidReader.java
@@ -1,0 +1,33 @@
+package com.example.contractservice.contract.service.batch.reader;
+
+import com.example.contractservice.contract.common.ContractStatus;
+import com.example.contractservice.contract.entity.ContractEntity;
+import jakarta.persistence.EntityManagerFactory;
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.database.JpaCursorItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@StepScope
+public class ContractPaidReader extends JpaCursorItemReader<ContractEntity> { // JpaPagingItemReader와 비교 필요
+
+    public ContractPaidReader(EntityManagerFactory emFactory,
+            @Value("#{jobParameters['dateStr']}") String dateStr,
+            @Value("${batch.contract.size}") int fetchSize) {
+        setEntityManagerFactory(emFactory);
+
+        setQueryString("""
+            SELECT c
+            FROM ContractEntity c
+            WHERE c.status = :status AND c.endedAt >= :time
+        """);
+
+        setHintValues(Map.of("org.hibernate.fetchSize", fetchSize));
+        Instant todayMidnight = Instant.parse(dateStr);
+
+        setParameterValues(Map.of("time", todayMidnight, "status", ContractStatus.PAID.name()));
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/batch/writer/ContractCancelledWriter.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/batch/writer/ContractCancelledWriter.java
@@ -1,0 +1,27 @@
+package com.example.contractservice.contract.service.batch.writer;
+
+import com.example.contractservice.contract.common.ContractStatus;
+import com.example.contractservice.contract.entity.ContractEntity;
+import com.example.contractservice.contract.event.dto.ContractEvent;
+import com.example.contractservice.contract.repository.ContractRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ContractCancelledWriter extends ContractStatusWriter {
+
+    public ContractCancelledWriter(ApplicationEventPublisher applicationEventPublisher,
+            ContractRepository contractRepository) {
+        super(applicationEventPublisher, contractRepository);
+    }
+
+    @Override
+    protected void changeStatus(ContractEntity contractEntity) {
+        contractEntity.updateStatus(ContractStatus.CANCELLED);
+    }
+
+    @Override
+    protected void publishEvent(ContractEntity contractEntity) {
+        applicationEventPublisher.publishEvent(new ContractEvent(contractEntity.getCode(), contractEntity.getCreatedAt(), ContractStatus.CANCELLED.name()));
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/batch/writer/ContractDoneWriter.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/batch/writer/ContractDoneWriter.java
@@ -1,0 +1,27 @@
+package com.example.contractservice.contract.service.batch.writer;
+
+import com.example.contractservice.contract.common.ContractStatus;
+import com.example.contractservice.contract.entity.ContractEntity;
+import com.example.contractservice.contract.event.dto.ContractEvent;
+import com.example.contractservice.contract.repository.ContractRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ContractDoneWriter extends ContractStatusWriter {
+
+    public ContractDoneWriter(ApplicationEventPublisher applicationEventPublisher,
+            ContractRepository contractRepository) {
+        super(applicationEventPublisher, contractRepository);
+    }
+
+    @Override
+    protected void changeStatus(ContractEntity contractEntity) {
+        contractEntity.updateStatus(ContractStatus.DONE);
+    }
+
+    @Override
+    protected void publishEvent(ContractEntity contractEntity) {
+        applicationEventPublisher.publishEvent(new ContractEvent(contractEntity.getCode(), contractEntity.getCreatedAt(), ContractStatus.DONE.name()));
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/batch/writer/ContractInProgressWriter.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/batch/writer/ContractInProgressWriter.java
@@ -1,0 +1,27 @@
+package com.example.contractservice.contract.service.batch.writer;
+
+import com.example.contractservice.contract.common.ContractStatus;
+import com.example.contractservice.contract.entity.ContractEntity;
+import com.example.contractservice.contract.event.dto.ContractEvent;
+import com.example.contractservice.contract.repository.ContractRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ContractInProgressWriter extends ContractStatusWriter {
+
+    public ContractInProgressWriter(ApplicationEventPublisher applicationEventPublisher,
+            ContractRepository contractRepository) {
+        super(applicationEventPublisher, contractRepository);
+    }
+
+    @Override
+    protected void changeStatus(ContractEntity contractEntity) {
+        contractEntity.updateStatus(ContractStatus.IN_PROGRESS);
+    }
+
+    @Override
+    protected void publishEvent(ContractEntity contractEntity) {
+        applicationEventPublisher.publishEvent(new ContractEvent(contractEntity.getCode(), contractEntity.getCreatedAt(), ContractStatus.IN_PROGRESS.name()));
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/batch/writer/ContractStatusWriter.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/batch/writer/ContractStatusWriter.java
@@ -1,0 +1,32 @@
+package com.example.contractservice.contract.service.batch.writer;
+
+import com.example.contractservice.contract.entity.ContractEntity;
+import com.example.contractservice.contract.repository.ContractRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.ApplicationEventPublisher;
+
+@StepScope
+@RequiredArgsConstructor
+public abstract class ContractStatusWriter implements ItemWriter<ContractEntity> {
+
+    protected final ApplicationEventPublisher applicationEventPublisher;
+    protected final ContractRepository contractRepository;
+
+    @Override
+    public void write(Chunk<? extends ContractEntity> chunk) {
+        chunk.forEach(contractEntity -> {
+            changeStatus(contractEntity);
+
+            contractRepository.saveContract(contractEntity);
+
+            publishEvent(contractEntity);
+        });
+    }
+
+    protected abstract void changeStatus(ContractEntity contractEntity);
+
+    protected abstract void publishEvent(ContractEntity contractEntity);
+}


### PR DESCRIPTION
## 📌 목적
각 계약의 상태는 자정을 기준으로 변경될 수 있습니다. 
`PAID`는 프로젝트 시작일에 도달하면 `IN_PROGRESS`가 될 수 있고, `CONFIRMED`는 프로젝트 시작일을 넘기면 `CANCELLED`가 됩니다. `IN_PROGRESS`는 프로젝트 종료일을 넘기면 `DONE`이 됩니다.

## ✅ 변경 사항
### 상태 변화 배치 개발
또 다른 Spring Batch를 추가했습니다. 추가된 Reader는 `ContractConfirmedReader`, `ContractInProgressReader`, `ContractPaidReader` 가 있으며 각각 해당하는 `status`를 가진 계약을 read합니다. 이번에도 일단은 `JpaCursorItemReader`로 구현했고, 추후 역시 `JpaPagingItemReader`와 비교해 보겠습니다!

`ItemWriter`는 사실상 달라지는 부분이 계약을 특정 상태로 바꾸고 이벤트 발행 `status`만 바꾸면 되어서 `ContractStatusWriter`라는 추상 클래스를 두고 `protected` 메서드만 구현하는 방식으로 구현해 보았습니다.

### 결제 검증 추가
배치 처리가 되기 전에 `CONFIRMED` 상태가 결제될 수 있습니다. 가능한 시간이 넘어서 `CANCELLED` 되어야 할 계약이 결제되면 안된다고 판단하여 결제 로직에 `startedAt`이 현재 시간보다 전이면 결제되지 않고 예외를 내게 됩니다.

## 🧪 테스트 방법
계약에 일부 임시 데이터를 넣고 배치 시간을 1분으로 설정하여 기다리거나 실제 테스트 코드로 실행할 수 있을 것 같은데 저는 전자의 방식으로 테스트 하였습니다.

## 📎 참고 사항
Resolve #67 

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [ ] 코드 컨벤션을 모두 지켰나요?
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
