### PR TITLE
fix(ci-cd): docker 버전 CI-CD develop 브랜치 적용

### DIFF
--- a/.github/workflows/cartpost-cd-workflow.yml
+++ b/.github/workflows/cartpost-cd-workflow.yml
@@ -3,7 +3,7 @@ name: cartpost-service ci/cd
 on:
   push:
     branches:
-      - test/ci-cd/119
+      - main
     paths:
       - 'cartpost-service/**'
 
@@ -19,7 +19,7 @@ jobs:
     with:
       service-name: hexagon-cartpost-service
       service-dir: ./cartpost-service
-      file-name: Dockerfile
+      file-name: Dockerfile_cartpost
 
   deploying:
     needs: releasing

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -6,10 +6,10 @@ on:
   pull_request:
     ## 어떤 브랜치로 발생했을 때
     branches:
-      - test/ci-cd/119
+      - main
 
-# 해당 job을 순서대로 실행하겠다.
-# 해당 jobs는 파이프라인 형태로 작동함.
+    # 해당 job을 순서대로 실행하겠다.
+    # 해당 jobs는 파이프라인 형태로 작동함.
     # 입력으로 들어와서 출력이 나가는게 다음 파이프의 입력으로 들어감
     # 잡은 병렬적으로 실행 될 수 있지만 파이프라인으로 구성되게 할 수 있음.
 jobs:
@@ -20,7 +20,6 @@ jobs:
     name: 코드 테스트
     # Action은 job 실행시 가상 환경을 이용함, 그래서 원래는 요금이 듬
     # 한달의 2000분 정도.
-    # 그래서 해당 프로젝트에서는 4팀이 같이 쓰니까 action을 간략화 해두었음.
     runs-on: ubuntu-latest
 
     steps:
@@ -41,55 +40,46 @@ jobs:
           mkdir -p ./cartpost-service/src/main/resources
           echo '${{ vars.CARTPOST_YML }}' > ./cartpost-service/src/main/resources/application.yml
           echo '${{ vars.TEST_YML }}' > ./cartpost-service/src/main/resources/application-test.yml
-
       - name: COMMUNICATION yml 생성
         run: |
           mkdir -p ./communication-service/src/main/resources
           echo '${{ vars.COMMUNICATION_YML }}' > ./communication-service/src/main/resources/application.yml
           echo '${{ vars.TEST_YML }}' > ./communication-service/src/main/resources/application-test.yml
-
       - name: CONTRACT yml 생성
         run: |
           mkdir -p ./contract-service/src/main/resources
           echo '${{ vars.CONTRACT_YML }}' > ./contract-service/src/main/resources/application.yml
           echo '${{ vars.TEST_YML }}' > ./contract-service/src/main/resources/application-test.yml
-
       - name: DISCOVERY yml 생성
         run: |
           mkdir -p ./discovery-service/src/main/resources
           echo '${{ vars.DISCOVERY_YML }}' > ./discovery-service/src/main/resources/application.yml
           echo '${{ vars.TEST_YML }}' > ./discovery-service/src/main/resources/application-test.yml
-
       - name: GATEWAY yml 생성
         run: |
           mkdir -p ./gateway-service/src/main/resources
           echo '${{ vars.GATEWAY_YML }}' > ./gateway-service/src/main/resources/application.yml
           echo '${{ vars.TEST_YML }}' > ./gateway-service/src/main/resources/application-test.yml
-
       - name: MEMBER yml 생성
         run: |
           mkdir -p ./member-service/src/main/resources
           echo '${{ vars.MEMBER_YML }}' > ./member-service/src/main/resources/application.yml
           echo '${{ vars.TEST_YML }}' > ./member-service/src/main/resources/application-test.yml
-
       - name: PAYMENT yml 생성
         run: |
           mkdir -p ./payment-service/src/main/resources
           echo '${{ vars.PAYMENT_YML }}' > ./payment-service/src/main/resources/application.yml
           echo '${{ vars.TEST_YML }}' > ./payment-service/src/main/resources/application-test.yml
-
       - name: PROFILE yml 생성
         run: |
           mkdir -p ./profile-service/src/main/resources
           echo '${{ vars.PROFILE_YML }}' > ./profile-service/src/main/resources/application.yml
           echo '${{ vars.TEST_YML }}' > ./profile-service/src/main/resources/application-test.yml
-
       - name: SEARCH yml 생성
         run: |
           mkdir -p ./search-service/src/main/resources
           echo '${{ vars.SEARCH_YML }}' > ./search-service/src/main/resources/application.yml
           echo '${{ vars.TEST_YML }}' > ./search-service/src/main/resources/application-test.yml
-
       - name: 전체 모듈 gradlew 권한 세팅
         run: |
           chmod +x ./cartpost-service/gradlew
@@ -101,14 +91,32 @@ jobs:
           chmod +x ./payment-service/gradlew
           chmod +x ./profile-service/gradlew
           chmod +x ./search-service/gradlew
-
       - name: Configure sysctl limits
         run: |
           sudo swapoff -a
           sudo sysctl -w vm.swappiness=1
           sudo sysctl -w fs.file-max=262144
           sudo sysctl -w vm.max_map_count=262144
-
+      - name: Run Kafka container and wait for ready
+        run: |
+          docker run -d \
+            --name kafka \
+            -p 9092:9092 \
+            -p 9091:9091 \
+            -p 9090:9090 \
+            -e KAFKA_NODE_ID=1 \
+            -e CLUSTER_ID=ZWU1Y2JiNDctNDg3ZC4tNGY2Ny1iNzJh \
+            -e KAFKA_PROCESS_ROLES=controller,broker \
+            -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:9091 \
+            -e KAFKA_LISTENERS=PLAINTEXT://:9090,CONTROLLER://:9091,EXTERNAL://:9092 \
+            -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9090,EXTERNAL://localhost:9092 \
+            -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT \
+            -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER \
+            -e KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT \
+            -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
+            -e KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1 \
+            -e KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1 \
+            apache/kafka
       - name: Elasticsearch docker run
         run: |
           docker run -d \
@@ -121,8 +129,6 @@ jobs:
             -e xpack.security.http.ssl.enabled=false \
             -e ES_JAVA_OPTS="-Xms512m -Xmx512m" \
             eddie1031/es:9.1.3
-
-
       - name: Wait for Elasticsearch to be up
         run: |
           for i in {1..10}; do
@@ -133,9 +139,6 @@ jobs:
             echo "Waiting for Elasticsearch..."
             sleep 8
           done
-
-      - name: application-test.properties 파일 내용 확인
-        run: cat ./search-service/src/main/resources/application-test.yml
 
       - name: search-service 테스트 실행
         working-directory: ./search-service
@@ -166,33 +169,37 @@ jobs:
 
       - name: member-service 테스트 실행
         working-directory: ./member-service
-        run: |
-          if [ -f ./gradlew ]; then
-            echo "gradlew exists"
-          fi
-          ./gradlew test --no-daemon -Dspring.profiles.active=test
+        run: ./gradlew test -Dspring.profiles.active=test --no-daemon --continue
+        continue-on-error: true
 
       - name: contract-service 테스트 실행
         working-directory: ./contract-service
-        run: ./gradlew test --no-daemon -Dspring.profiles.active=test
+        run: ./gradlew test -Dspring.profiles.active=test --no-daemon --continue
+        continue-on-error: true
 
       - name: cartpost-service 테스트 실행
         working-directory: ./cartpost-service
-        run: ./gradlew test --no-daemon -Dspring.profiles.active=test
+        run: ./gradlew test -Dspring.profiles.active=test --no-daemon --continue
+        continue-on-error: true
 
       - name: communication-service 테스트 실행
         working-directory: ./communication-service
-        run: ./gradlew test --no-daemon -Dspring.profiles.active=test
+        run: ./gradlew test -Dspring.profiles.active=test --no-daemon --continue
+        continue-on-error: true
 
       - name: payment-service 테스트 실행
         working-directory: ./payment-service
-        run: ./gradlew test --no-daemon -Dspring.profiles.active=test
+        run: ./gradlew test -Dspring.profiles.active=test --no-daemon --continue
+        continue-on-error: true
 
       - name: profile-service 테스트 실행
         working-directory: ./profile-service
-        run: ./gradlew test --no-daemon -Dspring.profiles.active=test
+        run: ./gradlew test -Dspring.profiles.active=test --no-daemon --continue
+        continue-on-error: true
 
-
-
-# Git의 Runners를 통해서 원격지 서버와의 연결을 설정
-# self-hosted runner는 
+      - name: Upload Test Reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-report
+          path: "**/build/reports/tests/test"

--- a/.github/workflows/communication-cd-workflow.yml
+++ b/.github/workflows/communication-cd-workflow.yml
@@ -3,7 +3,7 @@ name: communication-service ci/cd
 on:
   push:
     branches:
-      - test/ci-cd/119
+      - main
     paths:
       - 'communication-service/**'
 
@@ -20,7 +20,7 @@ jobs:
     with:
       service-name: hexagon-communication-service
       service-dir: ./communication-service
-      file-name: Dockerfile
+      file-name: Dockerfile_communication
 
   deploying:
     needs: releasing

--- a/.github/workflows/contract-cd-workflow.yml
+++ b/.github/workflows/contract-cd-workflow.yml
@@ -3,7 +3,7 @@ name: contract-service ci/cd
 on:
   push:
     branches:
-      - test/ci-cd/119
+      - main
     paths:
       - 'contract-service/**'
 
@@ -20,7 +20,7 @@ jobs:
     with:
       service-name: hexagon-contract-service
       service-dir: ./contract-service
-      file-name: Dockerfile
+      file-name: Dockerfile_contract
 
   deploying:
     needs: releasing

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -27,7 +27,6 @@ jobs:
           echo "Stopping and removing old container..."
           docker stop ${{ inputs.service-name }} || true
           docker rm ${{ inputs.service-name }} || true
-          IMAGE=${{ secrets.DOCKER_USERNAME }}/${{ inputs.service-name }}:${{ inputs.image-tag }}
           docker image prune -a -f
 
       - name: 도커 이미지 PULL 받기

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -27,6 +27,8 @@ jobs:
           echo "Stopping and removing old container..."
           docker stop ${{ inputs.service-name }} || true
           docker rm ${{ inputs.service-name }} || true
+          IMAGE=${{ secrets.DOCKER_USERNAME }}/${{ inputs.service-name }}:${{ inputs.image-tag }}
+          docker image prune -a -f
 
       - name: 도커 이미지 PULL 받기
         run: |

--- a/.github/workflows/dicovery-cd-workflow.yml
+++ b/.github/workflows/dicovery-cd-workflow.yml
@@ -3,7 +3,7 @@ name: discovery-service ci/cd
 on:
   push:
     branches:
-      - test/ci-cd/119
+      - main
     paths:
       - 'discovery-service/**'
 
@@ -20,7 +20,7 @@ jobs:
     with:
       service-name: hexagon-discovery-service
       service-dir: ./discovery-service
-      file-name: Dockerfile
+      file-name: Dockerfile_discovery
 
   deploying:
     needs: releasing

--- a/.github/workflows/gateway-cd-workflow.yml
+++ b/.github/workflows/gateway-cd-workflow.yml
@@ -3,7 +3,7 @@ name: gateway-service ci/cd
 on:
   push:
     branches:
-      - test/ci-cd/119
+      - main
     paths:
       - 'gateway-service/**'
 
@@ -20,7 +20,7 @@ jobs:
     with:
       service-name: hexagon-gateway-service
       service-dir: ./gateway-service
-      file-name: Dockerfile
+      file-name: Dockerfile_gateway
 
   deploying:
     needs: releasing

--- a/.github/workflows/member-cd-workflow.yml
+++ b/.github/workflows/member-cd-workflow.yml
@@ -3,7 +3,7 @@ name: member-service ci/cd
 on:
   push:
     branches:
-      - test/ci-cd/119
+      - main
     paths:
       - 'member-service/**'
 
@@ -20,7 +20,7 @@ jobs:
     with:
       service-name: hexagon-member-service
       service-dir: ./member-service
-      file-name: Dockerfile
+      file-name: Dockerfile_member
 
   deploying:
     needs: releasing

--- a/.github/workflows/payment-cd-workflow.yml
+++ b/.github/workflows/payment-cd-workflow.yml
@@ -3,7 +3,7 @@ name: payment-service ci/cd
 on:
   push:
     branches:
-      - test/ci-cd/119
+      - main
     paths:
       - 'payment-service/**'
 
@@ -20,7 +20,7 @@ jobs:
     with:
       service-name: hexagon-payment-service
       service-dir: ./payment-service
-      file-name: Dockerfile
+      file-name: Dockerfile_payment
 
   deploying:
     needs: releasing

--- a/.github/workflows/profile-cd-workflow.yml
+++ b/.github/workflows/profile-cd-workflow.yml
@@ -3,7 +3,7 @@ name: profile-service ci/cd
 on:
   push:
     branches:
-      - test/ci-cd/119
+      - main
     paths:
       - 'profile-service/**'
 
@@ -21,7 +21,7 @@ jobs:
     with:
       service-name: hexagon-profile-service
       service-dir: ./profile-service
-      file-name: Dockerfile
+      file-name: Dockerfile_profile
 
   deploying:
     needs: releasing

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -32,19 +32,22 @@ jobs:
     permissions:
       contents: write
 
-    concurrency:
-      group: "tagging-${{ github.ref_name }}"  # 브랜치 단위로 직렬화
-      cancel-in-progress: false
-
     steps:
       - uses: actions/checkout@v5
-
+#
+#      - name: versioning and tagging
+#        id: tag_version
+#        uses: mathieudutour/github-tag-action@v6.2
+#        with:
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          fetch_all_tags: 'true'
       - name: versioning and tagging
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          fetch_all_tags: 'true'
+        run: |
+          RANDOM_STR=$(openssl rand -hex 8)   # 예: a3f9c1d2bb44e21f
+          echo "Generated random string: $RANDOM_STR"
+          echo "new_tag=$RANDOM_STR" >> $GITHUB_OUTPUT
+          echo "changelog=자동 생성된 릴리즈 노트입니다." >> $GITHUB_OUTPUT
 
       - name: releasing
         uses: ncipollo/release-action@v1
@@ -92,8 +95,6 @@ jobs:
           else
           echo "알 수 없는 서비스입니다."
           fi
-          echo '${{ vars.TEST_YML }}' > ${{ inputs.service-dir }}/src/main/resources/application-test.yml
-          cat ${{ inputs.service-dir }}/src/main/resources/application.yml
 
       - name: Sign in github container registry
         uses: docker/login-action@v3
@@ -115,8 +116,8 @@ jobs:
       - name: Build and Push Image
         uses: docker/build-push-action@v6
         with:
-          context: ${{ inputs.service-dir }}
-          file: ${{ inputs.service-dir }}/${{ inputs.file-name }}
+          context: ./
+          file: ./${{ inputs.file-name }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/search-cd-workflow.yml
+++ b/.github/workflows/search-cd-workflow.yml
@@ -3,7 +3,7 @@ name: search-service ci/cd
 on:
   push:
     branches:
-      - test/ci-cd/119
+      - main
     paths:
       - 'search-service/**'
 
@@ -20,7 +20,7 @@ jobs:
     with:
       service-name: hexagon-search-service
       service-dir: ./search-service
-      file-name: Dockerfile
+      file-name: Dockerfile_search
 
   deploying:
     needs: releasing

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ build/
 
 !gradle-wrapper.properties
 !*-workflow.yml
+
+!docker-*

--- a/Dockerfile_cartpost
+++ b/Dockerfile_cartpost
@@ -1,0 +1,34 @@
+# 실행할 도커 환경 이미지
+FROM gradle:jdk17 AS builder
+
+# 작업을 수행할 가상환경 DIR
+# 앞으로 발생하는 모든 명령어는 WorkDIR을 기준으로 작성됨.
+WORKDIR /libs
+
+#COPY cartpost-service/gradlew ./cartpost-service/gradlew
+#COPY cartpost-service/gradle ./cartpost-service/gradle
+#COPY cartpost-service/build.gradle ./cartpost-service
+#COPY cartpost-service/settings.gradle ./cartpost-service
+
+# 즉 이거는 현재 위치에 있는 cartpost-service를
+# 가상 환경의 /libs에 cartpost-servic라는 폴더 생성
+COPY ./cartpost-service ./cartpost-service
+
+# cartpost-service 내 /gradlew 실행 권한 부여
+RUN chmod +x ./cartpost-service/gradlew
+
+# cartpost-service내 의존성 추가
+RUN ./cartpost-service/gradlew dependencies --no-daemon || true
+
+# /libs에 core 복사 /libs/core 로 카피
+COPY ./core ./core
+
+WORKDIR /libs/cartpost-service
+RUN ./gradlew build --no-daemon -x test
+
+FROM eclipse-temurin:17.0.10_7-jre
+
+WORKDIR /app
+
+COPY --from=builder /libs/cartpost-service/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile_communication
+++ b/Dockerfile_communication
@@ -1,0 +1,34 @@
+# 실행할 도커 환경 이미지
+FROM gradle:jdk17 AS builder
+
+# 작업을 수행할 가상환경 DIR
+# 앞으로 발생하는 모든 명령어는 WorkDIR을 기준으로 작성됨.
+WORKDIR /libs
+
+#COPY communication-service/gradlew ./communication-service/gradlew
+#COPY communication-service/gradle ./communication-service/gradle
+#COPY communication-service/build.gradle ./communication-service
+#COPY communication-service/settings.gradle ./communication-service
+
+# 즉 이거는 현재 위치에 있는 communication-service를
+# 가상 환경의 /libs에 communication-servic라는 폴더 생성
+COPY ./communication-service ./communication-service
+
+# communication-service 내 /gradlew 실행 권한 부여
+RUN chmod +x ./communication-service/gradlew
+
+# communication-service내 의존성 추가
+RUN ./communication-service/gradlew dependencies --no-daemon || true
+
+# /libs에 core 복사 /libs/core 로 카피
+COPY ./core ./core
+
+WORKDIR /libs/communication-service
+RUN ./gradlew build --no-daemon -x test
+
+FROM eclipse-temurin:17.0.10_7-jre
+
+WORKDIR /app
+
+COPY --from=builder /libs/communication-service/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile_contract
+++ b/Dockerfile_contract
@@ -1,0 +1,34 @@
+# 실행할 도커 환경 이미지
+FROM gradle:jdk17 AS builder
+
+# 작업을 수행할 가상환경 DIR
+# 앞으로 발생하는 모든 명령어는 WorkDIR을 기준으로 작성됨.
+WORKDIR /libs
+
+#COPY contract-service/gradlew ./contract-service/gradlew
+#COPY contract-service/gradle ./contract-service/gradle
+#COPY contract-service/build.gradle ./contract-service
+#COPY contract-service/settings.gradle ./contract-service
+
+# 즉 이거는 현재 위치에 있는 contract-service를
+# 가상 환경의 /libs에 contract-servic라는 폴더 생성
+COPY ./contract-service ./contract-service
+
+# contract-service 내 /gradlew 실행 권한 부여
+RUN chmod +x ./contract-service/gradlew
+
+# contract-service내 의존성 추가
+RUN ./contract-service/gradlew dependencies --no-daemon || true
+
+# /libs에 core 복사 /libs/core 로 카피
+COPY ./core ./core
+
+WORKDIR /libs/contract-service
+RUN ./gradlew build --no-daemon -x test
+
+FROM eclipse-temurin:17.0.10_7-jre
+
+WORKDIR /app
+
+COPY --from=builder /libs/contract-service/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile_discovery
+++ b/Dockerfile_discovery
@@ -1,0 +1,34 @@
+# 실행할 도커 환경 이미지
+FROM gradle:jdk17 AS builder
+
+# 작업을 수행할 가상환경 DIR
+# 앞으로 발생하는 모든 명령어는 WorkDIR을 기준으로 작성됨.
+WORKDIR /libs
+
+#COPY discovery-service/gradlew ./discovery-service/gradlew
+#COPY discovery-service/gradle ./discovery-service/gradle
+#COPY discovery-service/build.gradle ./discovery-service
+#COPY discovery-service/settings.gradle ./discovery-service
+
+# 즉 이거는 현재 위치에 있는 discovery-service를
+# 가상 환경의 /libs에 discovery-servic라는 폴더 생성
+COPY ./discovery-service ./discovery-service
+
+# discovery-service 내 /gradlew 실행 권한 부여
+RUN chmod +x ./discovery-service/gradlew
+
+# discovery-service내 의존성 추가
+RUN ./discovery-service/gradlew dependencies --no-daemon || true
+
+# /libs에 core 복사 /libs/core 로 카피
+COPY ./core ./core
+
+WORKDIR /libs/discovery-service
+RUN ./gradlew build --no-daemon -x test
+
+FROM eclipse-temurin:17.0.10_7-jre
+
+WORKDIR /app
+
+COPY --from=builder /libs/discovery-service/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile_gateway
+++ b/Dockerfile_gateway
@@ -1,0 +1,34 @@
+# 실행할 도커 환경 이미지
+FROM gradle:jdk17 AS builder
+
+# 작업을 수행할 가상환경 DIR
+# 앞으로 발생하는 모든 명령어는 WorkDIR을 기준으로 작성됨.
+WORKDIR /libs
+
+#COPY gateway-service/gradlew ./gateway-service/gradlew
+#COPY gateway-service/gradle ./gateway-service/gradle
+#COPY gateway-service/build.gradle ./gateway-service
+#COPY gateway-service/settings.gradle ./gateway-service
+
+# 즉 이거는 현재 위치에 있는 gateway-service를
+# 가상 환경의 /libs에 gateway-servic라는 폴더 생성
+COPY ./gateway-service ./gateway-service
+
+# gateway-service 내 /gradlew 실행 권한 부여
+RUN chmod +x ./gateway-service/gradlew
+
+# gateway-service내 의존성 추가
+RUN ./gateway-service/gradlew dependencies --no-daemon || true
+
+# /libs에 core 복사 /libs/core 로 카피
+COPY ./core ./core
+
+WORKDIR /libs/gateway-service
+RUN ./gradlew build --no-daemon -x test
+
+FROM eclipse-temurin:17.0.10_7-jre
+
+WORKDIR /app
+
+COPY --from=builder /libs/gateway-service/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile_member
+++ b/Dockerfile_member
@@ -1,0 +1,34 @@
+# 실행할 도커 환경 이미지
+FROM gradle:jdk17 AS builder
+
+# 작업을 수행할 가상환경 DIR
+# 앞으로 발생하는 모든 명령어는 WorkDIR을 기준으로 작성됨.
+WORKDIR /libs
+
+#COPY member-service/gradlew ./member-service/gradlew
+#COPY member-service/gradle ./member-service/gradle
+#COPY member-service/build.gradle ./member-service
+#COPY member-service/settings.gradle ./member-service
+
+# 즉 이거는 현재 위치에 있는 member-service를
+# 가상 환경의 /libs에 member-servic라는 폴더 생성
+COPY ./member-service ./member-service
+
+# member-service 내 /gradlew 실행 권한 부여
+RUN chmod +x ./member-service/gradlew
+
+# member-service내 의존성 추가
+RUN ./member-service/gradlew dependencies --no-daemon || true
+
+# /libs에 core 복사 /libs/core 로 카피
+COPY ./core ./core
+
+WORKDIR /libs/member-service
+RUN ./gradlew build --no-daemon -x test
+
+FROM eclipse-temurin:17.0.10_7-jre
+
+WORKDIR /app
+
+COPY --from=builder /libs/member-service/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile_payment
+++ b/Dockerfile_payment
@@ -1,0 +1,34 @@
+# 실행할 도커 환경 이미지
+FROM gradle:jdk17 AS builder
+
+# 작업을 수행할 가상환경 DIR
+# 앞으로 발생하는 모든 명령어는 WorkDIR을 기준으로 작성됨.
+WORKDIR /libs
+
+#COPY payment-service/gradlew ./payment-service/gradlew
+#COPY payment-service/gradle ./payment-service/gradle
+#COPY payment-service/build.gradle ./payment-service
+#COPY payment-service/settings.gradle ./payment-service
+
+# 즉 이거는 현재 위치에 있는 payment-service를
+# 가상 환경의 /libs에 payment-servic라는 폴더 생성
+COPY ./payment-service ./payment-service
+
+# payment-service 내 /gradlew 실행 권한 부여
+RUN chmod +x ./payment-service/gradlew
+
+# payment-service내 의존성 추가
+RUN ./payment-service/gradlew dependencies --no-daemon || true
+
+# /libs에 core 복사 /libs/core 로 카피
+COPY ./core ./core
+
+WORKDIR /libs/payment-service
+RUN ./gradlew build --no-daemon -x test
+
+FROM eclipse-temurin:17.0.10_7-jre
+
+WORKDIR /app
+
+COPY --from=builder /libs/payment-service/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile_profile
+++ b/Dockerfile_profile
@@ -1,0 +1,34 @@
+# 실행할 도커 환경 이미지
+FROM gradle:jdk17 AS builder
+
+# 작업을 수행할 가상환경 DIR
+# 앞으로 발생하는 모든 명령어는 WorkDIR을 기준으로 작성됨.
+WORKDIR /libs
+
+#COPY profile-service/gradlew ./profile-service/gradlew
+#COPY profile-service/gradle ./profile-service/gradle
+#COPY profile-service/build.gradle ./profile-service
+#COPY profile-service/settings.gradle ./profile-service
+
+# 즉 이거는 현재 위치에 있는 profile-service를
+# 가상 환경의 /libs에 profile-servic라는 폴더 생성
+COPY ./profile-service ./profile-service
+
+# profile-service 내 /gradlew 실행 권한 부여
+RUN chmod +x ./profile-service/gradlew
+
+# profile-service내 의존성 추가
+RUN ./profile-service/gradlew dependencies --no-daemon || true
+
+# /libs에 core 복사 /libs/core 로 카피
+COPY ./core ./core
+
+WORKDIR /libs/profile-service
+RUN ./gradlew build --no-daemon -x test
+
+FROM eclipse-temurin:17.0.10_7-jre
+
+WORKDIR /app
+
+COPY --from=builder /libs/profile-service/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile_search
+++ b/Dockerfile_search
@@ -1,0 +1,34 @@
+# 실행할 도커 환경 이미지
+FROM gradle:jdk17 AS builder
+
+# 작업을 수행할 가상환경 DIR
+# 앞으로 발생하는 모든 명령어는 WorkDIR을 기준으로 작성됨.
+WORKDIR /libs
+
+#COPY search-service/gradlew ./search-service/gradlew
+#COPY search-service/gradle ./search-service/gradle
+#COPY search-service/build.gradle ./search-service
+#COPY search-service/settings.gradle ./search-service
+
+# 즉 이거는 현재 위치에 있는 search-service를
+# 가상 환경의 /libs에 search-servic라는 폴더 생성
+COPY ./search-service ./search-service
+
+# search-service 내 /gradlew 실행 권한 부여
+RUN chmod +x ./search-service/gradlew
+
+# search-service내 의존성 추가
+RUN ./search-service/gradlew dependencies --no-daemon || true
+
+# /libs에 core 복사 /libs/core 로 카피
+COPY ./core ./core
+
+WORKDIR /libs/search-service
+RUN ./gradlew build --no-daemon -x test
+
+FROM eclipse-temurin:17.0.10_7-jre
+
+WORKDIR /app
+
+COPY --from=builder /libs/search-service/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/cartpost-service/build.gradle
+++ b/cartpost-service/build.gradle
@@ -52,4 +52,5 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	systemProperties = System.properties
 }

--- a/communication-service/build.gradle
+++ b/communication-service/build.gradle
@@ -46,4 +46,5 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	systemProperties = System.properties
 }

--- a/contract-service/build.gradle
+++ b/contract-service/build.gradle
@@ -81,6 +81,7 @@ dependencyManagement {
 
 tasks.named('test') {
     useJUnitPlatform()
+    systemProperties = System.properties
 }
 
 tasks.named('bootJar') {

--- a/discovery-service/build.gradle
+++ b/discovery-service/build.gradle
@@ -39,6 +39,7 @@ dependencyManagement {
 
 tasks.named('test') {
     useJUnitPlatform()
+    systemProperties = System.properties
 }
 
 tasks.named('bootJar') {

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -1,0 +1,55 @@
+
+services:
+  cartpost-service:
+    build:
+      context: .
+      dockerfile: Dockerfile_cartpost
+    image: cartpost-service:latest
+
+  communication-service:
+    build:
+      context: .
+      dockerfile: Dockerfile_communication
+    image: communication-service:latest
+
+  contract-service:
+    build:
+      context: .
+      dockerfile: Dockerfile_contract
+    image: contract-service:latest
+
+  discovery-service:
+    build:
+      context: .
+      dockerfile: Dockerfile_discovery
+    image: discovery-service:latest
+
+  gateway-service:
+    build:
+      context: .
+      dockerfile: Dockerfile_gateway
+    image: gateway-service:latest
+
+  member-service:
+    build:
+      context: .
+      dockerfile: Dockerfile_member
+    image: member-service:latest
+
+  payment-service:
+    build:
+      context: .
+      dockerfile: Dockerfile_payment
+    image: payment-service:latest
+
+  profile-service:
+    build:
+      context: .
+      dockerfile: Dockerfile_profile
+    image: profile-service:latest
+
+  search-service:
+    build:
+      context: .
+      dockerfile: Dockerfile_search
+    image: search-service:latest

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -1,0 +1,31 @@
+name: exp
+
+services:
+  cartpost-service:
+    image: cartpost-service:latest
+
+  communication-service:
+    image: communication-service:latest
+
+  contract-service:
+    image: contract-service:latest
+
+  discovery-service:
+    image: discovery-service:latest
+
+  gateway-service:
+    image: gateway-service:latest
+    ports:
+      - "8000:8000"
+
+  member-service:
+    image: member-service:latest
+
+  payment-service:
+    image: payment-service:latest
+
+  profile-service:
+    image: profile-service:latest
+
+  search-service:
+    image: search-service:latest

--- a/docker-compose-infra.yml
+++ b/docker-compose-infra.yml
@@ -1,0 +1,100 @@
+name: exp
+
+services:
+
+  db-mysql:
+    image: mysql
+    container_name: mysql
+    restart: unless-stopped
+    environment:
+      - MYSQL_DATABASE=hexagon
+      - MYSQL_ROOT_PASSWORD=1234
+      - TZ=Asia/Seoul
+    ports:
+      - "3308:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+  db-mongodb:
+    image: mongo:latest
+    container_name: mongodb
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_DATABASE: chatdb
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+
+  db-redis:
+    image: redis:7
+    container_name: redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+
+  kafka:
+    image: apache/kafka
+    container_name: kafka
+    restart: unless-stopped
+    environment:
+      - KAFKA_NODE_ID=1
+      - CLUSTER_ID=ZWU1Y2JiNDctNDg3ZC4tNGY2Ny1iNzJh
+      - KAFKA_PROCESS_ROLES=controller,broker
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:9091
+      - KAFKA_LISTENERS=PLAINTEXT://:9090,CONTROLLER://:9091,EXTERNAL://:9092
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9090,EXTERNAL://kafka:9092
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1
+    ports:
+      - "9092:9092"
+      - "9091:9091"
+      - "9090:9090"
+
+  elasticsearch:
+    image: eddie1031/es:9.1.3
+    container_name: elasticsearch
+    restart: unless-stopped
+    environment:
+      - node.name=es01
+      - cluster.name=cluster-exp
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.http.ssl.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    volumes:
+      - elasticsearch_data:/usr/share/elasticsearch/data
+
+  kibana:
+    image: kibana:9.1.3
+    container_name: kibana
+    restart: unless-stopped
+    ports:
+      - "5601:5601"
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+
+  nginx:
+    image: 'jc21/nginx-proxy-manager:latest'
+    container_name: nginx
+    restart: unless-stopped
+    ports:
+      - '80:80'
+      - '81:81'
+      - '443:443'
+    volumes:
+      - ./data:/data
+      - ./letsencrypt:/etc/letsencrypt
+      - /opt/websites:/mnt/user/appdata/NginxProxyManager/websites
+
+volumes:
+  mysql_data:
+  mongo_data:
+  elasticsearch_data:

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -56,4 +56,5 @@ dependencyManagement {
 
 tasks.named('test') {
     useJUnitPlatform()
+    systemProperties = System.properties
 }

--- a/member-service/build.gradle
+++ b/member-service/build.gradle
@@ -77,4 +77,5 @@ dependencyManagement {
 
 tasks.named('test') {
     useJUnitPlatform()
+    systemProperties = System.properties
 }

--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -56,4 +56,5 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
+    systemProperties = System.properties
 }

--- a/profile-service/build.gradle
+++ b/profile-service/build.gradle
@@ -50,4 +50,5 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	systemProperties = System.properties
 }

--- a/search-service/build.gradle
+++ b/search-service/build.gradle
@@ -58,4 +58,5 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	systemProperties = System.properties
 }


### PR DESCRIPTION
## 📌 목적
- 세미 프로젝트에서 실패했던 Docker 버전 CI-CD 적용 관련한 작업을 적용합니다.
- k3s 버전 작업 전 사용 가능한 CI-CD를 추가해두려는 목적입니다.

## ✅ 변경 사항

## 이전 세미프로젝트 때의 문제점
CI 관련
- 1. /gradlew test -Dspring.profiles.active=test 실행시 -Dspring.profiles.active=test가 적용되지 않는 문제
- 2. 특정 모듈의 테스트가 실패할 경우, 이후 다른 모듈의 테스트를 진행하지 않는 문제

CD 관련
- 1. 세미 프로젝트 마지막에 적용한 Core 모듈에 대한 DockerFile에 미적용시킨 문제
- 2. release 단계에서 release 동시성 문제

## /gradlew test -Dspring.profiles.active=test .. 을 실행시 profile을 test로 잡지 못하는 문제 해결

통일된 환경을 적용하기 위해 application-test.yml을 작성하였는데
실제 CI 스크립트를 실행해보면 지속적으로 contextLoad()가 실패하는 문제를 겪었습니다.
<img width="1136" height="228" alt="image" src="https://github.com/user-attachments/assets/d518dd24-9cb7-4514-834e-c13ddd26fb2b" />

분명 해당 Test 코드 실행에 **-Dspring.profiles.active=test** 설정을 추가했었기에 
이론적으로는 contextLoad()가 성공해야 하는데 계속 실패하는 것에 이상함을 느껴

로그를 **--debug 모드**로 확인해보았을 때 
**application-test.yml 내용이 아닌 application.yml 내용으로 Bean 등록을 시도하려해 실패**한다는 것을 알았습니다.

분명 **설정 값을 넣어줬는데도 왜 application.yml로 테스트 코드를 실행하는 지 정확한 이유를 알 지 못한 채**
설정 값이 먹히지 않는다면 Test Code에서 수동으로
직접 **@ActivateProfile("test")**를 추가 해줘 문제를 해결했었는 데 

@ZZAMBAs 인수님께서 
Build.gradle
```
tasks.named('test') {
    useJUnitPlatform()
}
```
부분에
    systemProperties = System.properties
을 추가해주면 문제가 해결된다는 것을 발견해주셨고 이를 적용하여 

해당 문제를 해결했습니다.

이렇게 문제를 해결하며 왜 **-Dspring.profiles.active=test**가 먹히지 않는 지도 추측이 가능해졌는데

**./gradlew test 명령어 실행시** 

JVM이 **일반 Gradle 처리 JVM과 Test 환경 JVm 두 개가 생성**된다고 합니다.

이 때 **해당 -Dspring.profiles.active는 ./gradlew**에 설정 값이라 
**일반 Gradle 처리 JVM에만 영향을 미치고**, Test 환경 **JVM까지는 적용이 되지 않았던 것**으로 추측을 하며

그래서 test 환경 JVM의 경우 -test.yml을 참조하지 않는 것 같습니다.

인수님께서 발견해주신 
**systemProperties = System.properties**
코드가 Test JVM을 구성할 때 
일반 Gradle JVM의 properties를 Test 환경 JVM에 적용시켜주는 코드기에 문제를 해결할 수 있었던 것 같습니다.

**추가적으로 강사님의 이야기를 들었을 때 위의 언급한 내용이 맞을 것 같다고 말씀해주셨으며, 
main.resources.application.yml 대신 test.resources.application.yml 을 작성해주면
위의 설정 없이도 작동을 할 것이라 조언해주셨습니다.**

## 특정 모듈의 테스트가 실패할 경우, 이후 다른 모듈의 테스트를 진행하지 않는 문제(?)
사실 문제가 되는 부분은 아니지만 
기존 Develop의 CI의 경우 9개 모듈 모두를 Test하는 데 
앞에서 실행된 Test가 실패할 경우 뒤에 실행되는 Test 모두 중단하고 CI를 실패했다는 결과를 출력하며 종료합니다.

그런 경우 각 CI 실행 시 실행되지 않은 뒷 부분의 Test 코드의 성공 여부를 알지 못하는 것이 문제라 판단하여,
인수님께서 성공 실패 상관없이 모든 Test Code를 실행하게 끔 구성해주시고,
각 모듈의 Test 결과를 파일로 관리할 수 있도록 작동해주었습니다.


## 세미 프로젝트 마지막에 적용한 Core 모듈에 대한 DockerFile에 미적용시킨 문제
이와 관련해서는 2단계로 문제가 발생했었는데

### 1. DockerFile에서 Core 모듈을 COPY해주지 않은 문제
세미 프로젝트 마지막 날, 전날까지 성공하던 CD가 실패하는 문제가 있었는 데,
이는 Kafka 메세지 Package를 위해 core 모듈의 추가했던 것이 문제 발생 원인으로 확인되었습니다.

Docker Image 빌드는 **host 디렉토리가 아닌** 
특정 이미지를 기반으로 해당 이미지 위(이후 '가상환경'으로 지칭)에서 수행이 하는데

core 모듈 COPY와 관련한 dockerfile 수정이 일어나지 않아
가상환경에서는 core 모듈이 없어 core 모듈을 include하는 모듈에서 jar 생성에 실패해 CD를 실패했던 것이었습니다.

그래서 각 모듈의 DockerFile에서

```
COPY ../core ./core
``` 
를 추가해 core 모듈에 대한 의존성이 가능하게 구성했지만

다음 두 번째 문제가 발생했습니다.

### 2. core 모듈 COPY 실패 문제
Git hub Action workflow 아래의 step에서 
도커 이미지를 빌드 및 push가 일어나도록 했었는데.
```
      - name: Build and Push Image
        uses: docker/build-push-action@v6
        with:
          context: ${{ inputs.service-dir }}
          file: ${{ inputs.service-dir }}/${{ inputs.file-name }}
          push: true
          tags: ${{ steps.meta.outputs.tags }}
          labels: ${{ steps.meta.outputs.labels }}
```

core 모듈을 COPY 하는 것에서 지속적으로 실패가 발생했고,
상대 경로가 잘못되었나부터 절대 경로로 해줘야하나 까지 

다양하게 시도를 해봤지만 모두 실패했고, 

docker 관련한 자료를 찾아본 결과 

docker build . 에서 해당 마지막 . 이 
docker build 시 참고할 context를 의미해서 

해당 context보다 상위의 데이터엔 접근할 수 없도록 보안 정책을 설정해두었다는 내용을 확인했습니다.

그래서 저는 각 모듈에서 관리하던 **Dokcerfile을 Root 프로젝트로 빼** 따로 구성을 해

**루트 위치에서 docker build .** 를 수행함으로써 build가 되게끔 해결했습니다.

근데 해당 방법에 대해 
2025년 11월 27일 4팀도 동일한 문제를 겪으며 강사님과 해결을 하는 것을 보았었는 데 
해당 문제에 대해
Docker file을 루트 프로젝트로 빼지 않고도

docker build 가 실행되는 위치만 root로 잡고 

특정 모듈의 있는 dockerfile을 실행하게 하면 된다는 해결책이 나왔습니다.

ex) 
기존에는 member 모듈안에서
docker build . 을 실행하게끔 했다면

docker build를 root 프로젝트에서 실행하고
docker build -f ./member-service/Dockerfile .

으로 Docker build Context를 Root로만 잡게하는 방식으로도 해결할 수 있다는 것을 알게 되었습니다.

이후 작업을 하신다면 참고 부탁드립니다!!


## release 동시성 문제
기존 Develop의 경우 **Release 관리를 위한 workflow**가 돌아가게 됩니다. 
해당 Release 관리 방법이

1. Github Action에게 현재 version 정보를 받아온다.
2. workflow가 현재 변경점을 반영해 다음 version 정보으로 gihub에 저장한다.

**낙관적 락과 유사하게 동작**하게 되는 데 이 때 문제가

변경이 있는 모듈이 모두 동시에 job이 돌아가게 된다면,
**1번 과정에서 모두 동일한 version 정보를 받아와 2번 과정에서 같은 version으로 쓰기**가 일어나게 되는 데 
이 때 **이미 같은 version으로 쓰기가 되어 있으니 실패**하게 됩니다.

이를 해결하기 위해서는

**1. release 기능을 포기
2. 모듈 별로 cd가 적용될 branch를 다 따로 만들기**

두 가지였고,

2번의 경우엔 관리가 너무 어려워질 것 같고, 저희가 Release 기능을 제대로 사용할 것 같지 않아
**1. release 기능을 포기**하는 것으로 결정했습니다.

이 때 tag로 사용할 값을 생성하던 release 과정이 사라졌기에 
항상 tag가 latest가 되어야할 텐데 이를 해결하기 위해 

@ZZAMBAs 인수님께서 랜덤 문자열을 생성하는 step을 추가해
docker 이미지 태그가 겹치지 않게해주었습니다.

## 논외 : 도커 이미지 제거하기
강사님의 CD 코드는 쿠버네티스라 다를 수 있지만

저희는 Docker를 사용한 배포를 구성했기에
한번 CD가 실행될 때마다 지속적으로 Docker Image가 축적되어 쌓이는 문제가 있습니다.

해당 문제 해결을 위해
CD 과정 중 
docker image prune -a -f 을 추가해주었습니다.


## 🧪 테스트 방법
- develop 대신 #119 과 관련한 branch 작업을 하며 직접 Action을 돌려보며 CI, CD 과정에서 발생하는 문제를 해결했습니다.



## 📎 참고 사항
- 관련 이슈, 화면 캡처, 참고 문서 등

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
