### PR TITLE
feat(s3): AWS S3 모듈 검증 로직 추가

### DIFF
--- a/s3-service/src/main/java/org/hexagon/s3service/controller/S3InternalController.java
+++ b/s3-service/src/main/java/org/hexagon/s3service/controller/S3InternalController.java
@@ -7,6 +7,7 @@ import org.hexagon.core.dto.Empty;
 import org.hexagon.core.dto.ResponseDto;
 import org.hexagon.s3service.controller.swagger.S3ControllerSwagger;
 import org.hexagon.s3service.controller.swagger.S3InternalControllerSwagger;
+import org.hexagon.s3service.dto.ExistsResponse;
 import org.hexagon.s3service.dto.PresignedDownloadListResponse;
 import org.hexagon.s3service.dto.PresignedDownloadRequestByCode;
 import org.hexagon.s3service.dto.PresignedDownloadRequestByKey;
@@ -16,11 +17,13 @@ import org.hexagon.core.vo.ServiceName;
 import org.hexagon.s3service.dto.StoreKeysRequest;
 import org.hexagon.s3service.service.S3Service;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -70,5 +73,11 @@ public class S3InternalController implements S3InternalControllerSwagger {
         }
         s3Service.syncAttachments(request.code(), keys);
         return ResponseDto.success(HttpStatus.CREATED);
+    }
+
+    @GetMapping("/exists")
+    public ResponseDto<ExistsResponse> exists(@RequestParam String key) {
+        ExistsResponse response = s3Service.exists(key);
+        return ResponseDto.success(response);
     }
 }

--- a/s3-service/src/main/java/org/hexagon/s3service/dto/ExistsResponse.java
+++ b/s3-service/src/main/java/org/hexagon/s3service/dto/ExistsResponse.java
@@ -1,0 +1,8 @@
+package org.hexagon.s3service.dto;
+
+public record ExistsResponse(
+        String key,
+        Boolean exists
+) {
+
+}

--- a/s3-service/src/main/java/org/hexagon/s3service/exception/GlobalExceptionHandler.java
+++ b/s3-service/src/main/java/org/hexagon/s3service/exception/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package org.hexagon.s3service.exception;
+
+import org.hexagon.core.dto.Empty;
+import org.hexagon.core.dto.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import software.amazon.awssdk.core.exception.SdkException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(SdkException.class)
+    public ResponseDto<Empty> handleException(SdkException e) {
+        return new ResponseDto<>(
+                5000,
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "S3 SDK 오류가 발생했습니다.",
+                Empty.getInstance()
+        );
+    }
+}

--- a/s3-service/src/main/java/org/hexagon/s3service/exception/GlobalExceptionHandler.java
+++ b/s3-service/src/main/java/org/hexagon/s3service/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.hexagon.s3service.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.hexagon.core.dto.Empty;
 import org.hexagon.core.dto.ResponseDto;
 import org.springframework.http.HttpStatus;
@@ -8,10 +9,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import software.amazon.awssdk.core.exception.SdkException;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(SdkException.class)
     public ResponseDto<Empty> handleException(SdkException e) {
+        log.error(e.getMessage(), e);
         return new ResponseDto<>(
                 5000,
                 HttpStatus.INTERNAL_SERVER_ERROR.value(),

--- a/s3-service/src/main/java/org/hexagon/s3service/service/S3Service.java
+++ b/s3-service/src/main/java/org/hexagon/s3service/service/S3Service.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.hexagon.s3service.dto.ExistsResponse;
 import org.hexagon.s3service.dto.PresignedDownloadListResponse;
 import org.hexagon.s3service.dto.PresignedDownloadResponse;
 import org.hexagon.s3service.dto.PresignedUploadResponse;
@@ -21,7 +22,9 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
@@ -205,6 +208,23 @@ public class S3Service {
                 deleteObject(oldKey);
                 s3ResourceRepository.deleteByKey(oldKey);
             }
+        }
+    }
+
+    public ExistsResponse exists(String key) {
+        try {
+            HeadObjectRequest request = HeadObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+
+            s3Client.headObject(request); // 파일이 존재하지 않는 경우 S3Exception
+            return new ExistsResponse(key, true);
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) { // 파일이 존재하지 않는 경우
+                return new ExistsResponse(key, false);
+            }
+            throw e; // 기타 예외
         }
     }
 }


### PR DESCRIPTION
## 🐛 관련 이슈
Closes #170 

## 📌 목적
- 채팅 모듈에서 DB에 Key를 저장하기 전에 해당 파일이 실제로 S3 버킷에 존재하는지 여부를 검증합니다.
- S3 SDK 에러 핸들러를 구성합니다.

## ✅ 변경 사항
- 이번 PR은 아주 작은 변경 사항만 존재합니다.
- Internal Controller에 Key에 해당하는 파일이 실제로 S3 버킷에 존재하는지 여부를 검증하는 API가 추가되었습니다.
- exception 패키지에 S3 SDK 에러 핸들러가 추가되었습니다.
  - S3 SDK 에러는 네트워크 오류 등 특수한 상황에서만 발생하기 때문에 발생 가능성이 아주 희박하다고 생각해서 간단하게 핸들러를 구성했습니다.

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [x] 이슈 번호를 입력 했나요?
- [ ] 코드 컨벤션을 모두 지켰나요?
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
