### PR TITLE
feat(chat): 채팅 메시지에 파일 정보 추가

### DIFF
--- a/communication-service/src/main/java/com/example/communicationservice/common/exception/ChatMessageException.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/exception/ChatMessageException.java
@@ -1,0 +1,11 @@
+package com.example.communicationservice.common.exception;
+
+import com.example.communicationservice.common.status.ResponseDtoStatus;
+
+public class ChatMessageException extends CustomException {
+
+    public ChatMessageException(ResponseDtoStatus status) {
+        super(status);
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/common/status/ResponseDtoStatus.java
+++ b/communication-service/src/main/java/com/example/communicationservice/common/status/ResponseDtoStatus.java
@@ -17,6 +17,15 @@ public enum ResponseDtoStatus {
     CHATROOM_NOT_FOUND(1004, "채팅방이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     CHATROOM_FORBIDDEN(1005, "해당 채팅방에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
+    // 채팅 메시지 관련 실패
+    TEXT_MISSING(1100, "텍스트 메시지가 비어있습니다.", HttpStatus.BAD_REQUEST),
+    TOO_LONG_TEXT(1101, "텍스트 메시지가 길이 제한을 초과했습니다.", HttpStatus.BAD_REQUEST),
+    FILE_MISSING(1102, "파일이 필요합니다.", HttpStatus.BAD_REQUEST),
+    MESSAGE_TYPE_MISSING(1103, "메시지 타입이 필요합니다.", HttpStatus.BAD_REQUEST),
+    FILE_NOT_ALLOWED(1104, "텍스트 메시지에는 파일이 포함될 수 없습니다.", HttpStatus.BAD_REQUEST),
+    FILE_KEY_MISSING(1105, "파일 key가 필요합니다.", HttpStatus.BAD_REQUEST),
+    TEXT_NOT_ALLOWED(1106, "파일 메시지에는 텍스트가 포함될 수 없습니다.", HttpStatus.BAD_REQUEST),
+
     // 유효성 검사 실패
     VALIDATION_FAILED(40000, "유효하지 않은 입력입니다.", HttpStatus.BAD_REQUEST),
 

--- a/communication-service/src/main/java/com/example/communicationservice/controller/ChatMessageController.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/ChatMessageController.java
@@ -6,11 +6,13 @@ import com.example.communicationservice.common.exception.ChatRoomException;
 import com.example.communicationservice.controller.dto.request.ChatMessageSendRequest;
 import com.example.communicationservice.controller.dto.response.ChatMessageSendResponse;
 import com.example.communicationservice.service.ChatMessageService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.hexagon.core.dto.Empty;
 import org.hexagon.core.dto.ResponseDto;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
@@ -29,10 +31,8 @@ public class ChatMessageController {
      * 3. 해당 토픽 구독자에게 메시지 전송
      */
     @MessageMapping("chat.send")
-    public void handleChatMessage(ChatMessageSendRequest request) {
-        ChatMessageSendResponse response = chatMessageService.saveMessage(
-            request.roomId(), request.senderCode(), request.content()
-        );
+    public void handleChatMessage(@Valid @Payload ChatMessageSendRequest request) {
+        ChatMessageSendResponse response = chatMessageService.saveMessage(request);
 
         String destinationPrefix = "/queue/room/";
         messagingTemplate.convertAndSend(destinationPrefix + request.roomId(), response);

--- a/communication-service/src/main/java/com/example/communicationservice/controller/ChatRoomController.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/ChatRoomController.java
@@ -32,10 +32,7 @@ public class ChatRoomController implements ChatRoomControllerApi {
         @Valid @RequestBody ChatRoomCreateRequest request,
         @RequestHeader(name = "X-CODE") String currentMemberCode
     ) {
-        ChatRoomCreateResponse response = chatRoomService.createChatRoom(
-            request.name(), request.memberCodes(),
-            currentMemberCode
-        );
+        ChatRoomCreateResponse response = chatRoomService.createChatRoom(request, currentMemberCode);
 
         return ResponseEntity
             .status(HttpStatus.CREATED)

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/FileInfo.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/FileInfo.java
@@ -1,19 +1,6 @@
 package com.example.communicationservice.controller.dto;
 
-import com.example.communicationservice.entity.File;
-
 public record FileInfo(
     String key
 ) {
-    public static FileInfo from(File file) {
-        if (file == null) {
-            return null;
-        }
-
-        return new FileInfo(file.getKey());
-    }
-
-    public File toDomain() {
-        return File.builder().key(key).build();
-    }
 }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/FileInfo.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/FileInfo.java
@@ -1,0 +1,19 @@
+package com.example.communicationservice.controller.dto;
+
+import com.example.communicationservice.entity.File;
+
+public record FileInfo(
+    String key
+) {
+    public static FileInfo from(File file) {
+        if (file == null) {
+            return null;
+        }
+
+        return new FileInfo(file.getKey());
+    }
+
+    public File toDomain() {
+        return File.builder().key(key).build();
+    }
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatMessageSendRequest.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatMessageSendRequest.java
@@ -1,7 +1,6 @@
 package com.example.communicationservice.controller.dto.request;
 
 import com.example.communicationservice.controller.dto.FileInfo;
-import com.example.communicationservice.entity.ChatMessage;
 import com.example.communicationservice.type.MessageType;
 import jakarta.validation.constraints.NotNull;
 
@@ -21,13 +20,4 @@ public record ChatMessageSendRequest(
     FileInfo file
 
 ) {
-    public ChatMessage toEntity() {
-        return ChatMessage.builder()
-            .roomId(roomId)
-            .senderCode(senderCode)
-            .type(type)
-            .text(text)
-            .file(file != null ? file.toDomain() : null)
-            .build();
-    }
 }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatMessageSendRequest.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatMessageSendRequest.java
@@ -1,8 +1,33 @@
 package com.example.communicationservice.controller.dto.request;
 
+import com.example.communicationservice.controller.dto.FileInfo;
+import com.example.communicationservice.entity.ChatMessage;
+import com.example.communicationservice.type.MessageType;
+import jakarta.validation.constraints.NotNull;
+
 public record ChatMessageSendRequest(
+
+    @NotNull
     String roomId,
+
+    @NotNull
     String senderCode,
-    String content
+
+    @NotNull
+    MessageType type,
+
+    String text,
+
+    FileInfo file
+
 ) {
+    public ChatMessage toEntity() {
+        return ChatMessage.builder()
+            .roomId(roomId)
+            .senderCode(senderCode)
+            .type(type)
+            .text(text)
+            .file(file != null ? file.toDomain() : null)
+            .build();
+    }
 }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageReadResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageReadResponse.java
@@ -1,20 +1,26 @@
 package com.example.communicationservice.controller.dto.response;
 
+import com.example.communicationservice.controller.dto.FileInfo;
 import com.example.communicationservice.entity.ChatMessage;
+import com.example.communicationservice.type.MessageType;
 
 import java.time.Instant;
 
 public record ChatMessageReadResponse(
     String id,
     String senderCode,
-    String content,
+    MessageType type,
+    String text,
+    FileInfo file,
     Instant sentAt
 ) {
     public static ChatMessageReadResponse from(ChatMessage message) {
         return new ChatMessageReadResponse(
             message.getId(),
             message.getSenderCode(),
-            message.getContent(),
+            message.getType(),
+            message.getText(),
+            FileInfo.from(message.getFile()),
             message.getSentAt()
         );
     }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageReadResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageReadResponse.java
@@ -1,7 +1,6 @@
 package com.example.communicationservice.controller.dto.response;
 
 import com.example.communicationservice.controller.dto.FileInfo;
-import com.example.communicationservice.entity.ChatMessage;
 import com.example.communicationservice.type.MessageType;
 
 import java.time.Instant;
@@ -14,14 +13,4 @@ public record ChatMessageReadResponse(
     FileInfo file,
     Instant sentAt
 ) {
-    public static ChatMessageReadResponse from(ChatMessage message) {
-        return new ChatMessageReadResponse(
-            message.getId(),
-            message.getSenderCode(),
-            message.getType(),
-            message.getText(),
-            FileInfo.from(message.getFile()),
-            message.getSentAt()
-        );
-    }
 }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageSendResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageSendResponse.java
@@ -1,6 +1,8 @@
 package com.example.communicationservice.controller.dto.response;
 
+import com.example.communicationservice.controller.dto.FileInfo;
 import com.example.communicationservice.entity.ChatMessage;
+import com.example.communicationservice.type.MessageType;
 
 import java.time.Instant;
 
@@ -8,7 +10,9 @@ public record ChatMessageSendResponse(
     String messageId,
     String roomId,
     String senderCode,
-    String content,
+    MessageType type,
+    String text,
+    FileInfo file,
     Instant sentAt
 ) {
     public static ChatMessageSendResponse from(ChatMessage message) {
@@ -16,7 +20,9 @@ public record ChatMessageSendResponse(
             message.getId(),
             message.getRoomId(),
             message.getSenderCode(),
-            message.getContent(),
+            message.getType(),
+            message.getText(),
+            FileInfo.from(message.getFile()),
             message.getSentAt()
         );
     }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageSendResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageSendResponse.java
@@ -1,7 +1,6 @@
 package com.example.communicationservice.controller.dto.response;
 
 import com.example.communicationservice.controller.dto.FileInfo;
-import com.example.communicationservice.entity.ChatMessage;
 import com.example.communicationservice.type.MessageType;
 
 import java.time.Instant;
@@ -15,15 +14,4 @@ public record ChatMessageSendResponse(
     FileInfo file,
     Instant sentAt
 ) {
-    public static ChatMessageSendResponse from(ChatMessage message) {
-        return new ChatMessageSendResponse(
-            message.getId(),
-            message.getRoomId(),
-            message.getSenderCode(),
-            message.getType(),
-            message.getText(),
-            FileInfo.from(message.getFile()),
-            message.getSentAt()
-        );
-    }
 }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatRoomCreateResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatRoomCreateResponse.java
@@ -1,11 +1,6 @@
 package com.example.communicationservice.controller.dto.response;
 
-import com.example.communicationservice.entity.ChatRoom;
-
 public record ChatRoomCreateResponse(
     String id
 ) {
-    public static ChatRoomCreateResponse from(ChatRoom chatRoom) {
-        return new ChatRoomCreateResponse(chatRoom.getId());
-    }
 }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatRoomReadResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatRoomReadResponse.java
@@ -1,7 +1,5 @@
 package com.example.communicationservice.controller.dto.response;
 
-import com.example.communicationservice.entity.ChatRoom;
-
 import java.time.Instant;
 
 public record ChatRoomReadResponse(
@@ -9,11 +7,4 @@ public record ChatRoomReadResponse(
     String name,
     Instant updatedAt
 ) {
-    public static ChatRoomReadResponse from(ChatRoom chatRoom) {
-        return new ChatRoomReadResponse(
-            chatRoom.getId(),
-            chatRoom.getName(),
-            chatRoom.getUpdatedAt()
-        );
-    }
 }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/PageInfo.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/PageInfo.java
@@ -1,19 +1,9 @@
 package com.example.communicationservice.controller.dto.response;
 
-import org.springframework.data.domain.Page;
-
 public record PageInfo(
     int page, // 현재 페이지 번호(0-based)
     int size, // 페이지당 항목 수
     long totalElements, // 전체 항목 수
     int totalPages // 전체 페이지수
 ) {
-    public static PageInfo from(Page<?> page) {
-        return new PageInfo(
-            page.getNumber(),
-            page.getSize(),
-            page.getTotalElements(),
-            page.getTotalPages()
-        );
-    }
 }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/PageInfo.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/PageInfo.java
@@ -4,6 +4,7 @@ public record PageInfo(
     int page, // 현재 페이지 번호(0-based)
     int size, // 페이지당 항목 수
     long totalElements, // 전체 항목 수
-    int totalPages // 전체 페이지수
+    int totalPages, // 전체 페이지 수
+    boolean hasNext // 다음 페이지 존재 여부
 ) {
 }

--- a/communication-service/src/main/java/com/example/communicationservice/entity/ChatMessage.java
+++ b/communication-service/src/main/java/com/example/communicationservice/entity/ChatMessage.java
@@ -1,5 +1,8 @@
 package com.example.communicationservice.entity;
 
+import com.example.communicationservice.common.exception.ChatMessageException;
+import com.example.communicationservice.common.status.ResponseDtoStatus;
+import com.example.communicationservice.type.MessageType;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,16 +25,36 @@ public class ChatMessage {
 
     private String senderCode;
 
-    private String content;
+    private MessageType type;
+
+    private String text;
+
+    private File file;
 
     @CreatedDate
     private Instant sentAt; // 전송된 시간
 
     @Builder
-    private ChatMessage(String roomId, String senderCode, String content) {
+    private ChatMessage(
+        String roomId,
+        String senderCode,
+        MessageType type,
+        String text,
+        File file
+    ) {
+        // 메시지 타입 null 체크
+        if (type == null) {
+            throw new ChatMessageException(ResponseDtoStatus.MESSAGE_TYPE_MISSING);
+        }
+
         this.roomId = roomId;
         this.senderCode = senderCode;
-        this.content = content;
+        this.type = type;
+        this.text = text;
+        this.file = file;
+
+        // 타입별 유효성 검증
+        type.validate(this);
     }
 
 }

--- a/communication-service/src/main/java/com/example/communicationservice/entity/File.java
+++ b/communication-service/src/main/java/com/example/communicationservice/entity/File.java
@@ -1,0 +1,19 @@
+package com.example.communicationservice.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class File {
+
+    String key;
+
+    @Builder
+    private File(String key) {
+        this.key = key;
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/mapper/ChatMapper.java
+++ b/communication-service/src/main/java/com/example/communicationservice/mapper/ChatMapper.java
@@ -1,0 +1,96 @@
+package com.example.communicationservice.mapper;
+
+import com.example.communicationservice.controller.dto.FileInfo;
+import com.example.communicationservice.controller.dto.request.ChatMessageSendRequest;
+import com.example.communicationservice.controller.dto.response.*;
+import com.example.communicationservice.entity.ChatMessage;
+import com.example.communicationservice.entity.ChatRoom;
+import com.example.communicationservice.entity.File;
+import org.springframework.data.domain.Page;
+
+// dto와 entity 사이의 변환 로직 전담
+public abstract class ChatMapper {
+
+    private ChatMapper() {} // 인스턴스화 방지
+
+    // ------------------ ChatMessage ------------------
+
+    public static ChatMessage toEntity(ChatMessageSendRequest request) {
+        return ChatMessage.builder()
+            .roomId(request.roomId())
+            .senderCode(request.senderCode())
+            .type(request.type())
+            .text(request.text())
+            .file(request.file() != null ? toEntity(request.file()) : null)
+            .build();
+    }
+
+    public static ChatMessageReadResponse toReadResponse(ChatMessage message) {
+        return new ChatMessageReadResponse(
+            message.getId(),
+            message.getSenderCode(),
+            message.getType(),
+            message.getText(),
+            from(message.getFile()),
+            message.getSentAt()
+        );
+    }
+
+    public static ChatMessageSendResponse toSendResponse(ChatMessage message) {
+        return new ChatMessageSendResponse(
+            message.getId(),
+            message.getRoomId(),
+            message.getSenderCode(),
+            message.getType(),
+            message.getText(),
+            from(message.getFile()),
+            message.getSentAt()
+        );
+    }
+
+    // ------------------ ChatRoom ------------------
+
+    public static ChatRoomCreateResponse toCreateResponse(ChatRoom chatRoom) {
+        return new ChatRoomCreateResponse(chatRoom.getId());
+    }
+
+    public static ChatRoomReadResponse toReadResponse(ChatRoom chatRoom) {
+        return new ChatRoomReadResponse(
+            chatRoom.getId(),
+            chatRoom.getName(),
+            chatRoom.getUpdatedAt()
+        );
+    }
+
+    // ------------------ Paging ------------------
+
+    public static PageInfo toPageInfo(Page<?> page) {
+        return new PageInfo(
+            page.getNumber(),
+            page.getSize(),
+            page.getTotalElements(),
+            page.getTotalPages()
+        );
+    }
+
+    // ------------------ File ------------------
+
+    public static FileInfo from(File file) {
+        if (file == null) {
+            return null;
+        }
+
+        return new FileInfo(file.getKey());
+    }
+
+    public static File toEntity(FileInfo fileInfo) {
+        if (fileInfo == null) {
+            return null;
+        }
+
+        return File.builder()
+            .key(fileInfo.key())
+            .build();
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/mapper/ChatMapper.java
+++ b/communication-service/src/main/java/com/example/communicationservice/mapper/ChatMapper.java
@@ -69,7 +69,8 @@ public abstract class ChatMapper {
             page.getNumber(),
             page.getSize(),
             page.getTotalElements(),
-            page.getTotalPages()
+            page.getTotalPages(),
+            page.hasNext()
         );
     }
 

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
@@ -2,12 +2,14 @@ package com.example.communicationservice.service;
 
 import com.example.communicationservice.common.exception.ChatRoomException;
 import com.example.communicationservice.common.status.ResponseDtoStatus;
+import com.example.communicationservice.controller.dto.request.ChatMessageSendRequest;
 import com.example.communicationservice.controller.dto.response.ChatMessageListReadResponse;
 import com.example.communicationservice.controller.dto.response.ChatMessageReadResponse;
 import com.example.communicationservice.controller.dto.response.ChatMessageSendResponse;
 import com.example.communicationservice.controller.dto.response.PageInfo;
 import com.example.communicationservice.entity.ChatMessage;
 import com.example.communicationservice.entity.ChatRoom;
+import com.example.communicationservice.mapper.ChatMapper;
 import com.example.communicationservice.repository.ChatMessageRepository;
 import com.example.communicationservice.repository.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
@@ -47,38 +49,33 @@ public class ChatMessageService {
 
         // 엔티티 -> DTO 변환
         List<ChatMessageReadResponse> messages = messagePage.getContent().stream()
-            .map(ChatMessageReadResponse::from)
+            .map(ChatMapper::toReadResponse)
             .toList();
 
         // Page 정보 추출 및 DTO 생성
-        PageInfo pageInfo = PageInfo.from(messagePage);
+        PageInfo pageInfo = ChatMapper.toPageInfo(messagePage);
 
         return new ChatMessageListReadResponse(messages, pageInfo);
     }
 
     /**
      * 특정 채팅방의 메시지를 저장합니다.
-     * @param roomId 해당 채팅방 아이디
-     * @param senderCode 메시지 송신자 코드
-     * @param content 메시지 내용
+     * @param request 저장할 채팅 메시지 전송 요청
      * @return 수신할 메시지
      */
     @Transactional
-    public ChatMessageSendResponse saveMessage(String roomId, String senderCode, String content) {
+    public ChatMessageSendResponse saveMessage(ChatMessageSendRequest request) {
         // 해당 채팅방이 존재하는지 확인
-        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+        ChatRoom chatRoom = chatRoomRepository.findById(request.roomId())
             .orElseThrow(() -> new ChatRoomException(ResponseDtoStatus.CHATROOM_NOT_FOUND));
 
         // 메시지 송신자가 해당 채팅방의 참여자인지 확인
-        if (!chatRoom.getMemberCodes().contains(senderCode)) {
+        if (!chatRoom.getMemberCodes().contains(request.senderCode())) {
             throw new ChatRoomException(ResponseDtoStatus.CHATROOM_FORBIDDEN);
         }
 
-        ChatMessage chatMessage = ChatMessage.builder()
-            .roomId(roomId)
-            .senderCode(senderCode)
-            .content(content)
-            .build();
+        // 메시지 생성 및 타입별 유효성 자동 검증
+        ChatMessage chatMessage = ChatMapper.toEntity(request);
 
         ChatMessage savedChatMessage = chatMessageRepository.save(chatMessage);
 
@@ -86,7 +83,7 @@ public class ChatMessageService {
         chatRoom.setUpdatedAt(Instant.now());
         chatRoomRepository.save(chatRoom);
 
-        return ChatMessageSendResponse.from(savedChatMessage);
+        return ChatMapper.toSendResponse(savedChatMessage);
     }
 
 }

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
@@ -4,11 +4,13 @@ import com.example.communicationservice.client.MemberServiceClient;
 import com.example.communicationservice.client.dto.MemberExistOutput;
 import com.example.communicationservice.common.exception.ChatRoomException;
 import com.example.communicationservice.common.status.ResponseDtoStatus;
+import com.example.communicationservice.controller.dto.request.ChatRoomCreateRequest;
 import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
 import com.example.communicationservice.controller.dto.response.ChatRoomListReadResponse;
 import com.example.communicationservice.controller.dto.response.ChatRoomReadResponse;
 import com.example.communicationservice.controller.dto.response.PageInfo;
 import com.example.communicationservice.entity.ChatRoom;
+import com.example.communicationservice.mapper.ChatMapper;
 import com.example.communicationservice.repository.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -26,12 +28,13 @@ public class ChatRoomService {
 
     /**
      * 새로운 채팅방을 생성하고 저장합니다.
-     * @param name 채팅방 이름
-     * @param memberCodes 채팅방 참여자들의 코드 목록
+     * @param request 채팅방 생성 요청
      * @param currentMemberCode 현재 로그인한 회원의 코드
      * @return 생성된 채팅방 아이디
      */
-    public ChatRoomCreateResponse createChatRoom(String name, List<String> memberCodes, String currentMemberCode) {
+    public ChatRoomCreateResponse createChatRoom(ChatRoomCreateRequest request, String currentMemberCode) {
+        List<String> memberCodes = request.memberCodes();
+
         // 1:1 채팅인지 확인
         if (memberCodes.stream().distinct().count() != 2) {
             throw new ChatRoomException(ResponseDtoStatus.CHATROOM_INVALID_MEMBER_COUNT);
@@ -56,14 +59,14 @@ public class ChatRoomService {
 
         // 채팅방 생성
         ChatRoom chatRoom = ChatRoom.builder()
-            .name(name)
+            .name(request.name())
             .memberCodes(memberCodes)
             .build();
 
         // 채팅방 저장
         ChatRoom createdChatRoom = chatRoomRepository.save(chatRoom);
 
-        return ChatRoomCreateResponse.from(createdChatRoom);
+        return ChatMapper.toCreateResponse(createdChatRoom);
     }
 
     /**
@@ -77,11 +80,11 @@ public class ChatRoomService {
 
         // 엔티티 -> DTO 변환
         List<ChatRoomReadResponse> chatRooms = chatRoomPage.getContent().stream()
-            .map(ChatRoomReadResponse::from)
+            .map(ChatMapper::toReadResponse)
             .toList();
 
         // Page 정보 추출 및 DTO 생성
-        PageInfo pageInfo = PageInfo.from(chatRoomPage);
+        PageInfo pageInfo = ChatMapper.toPageInfo(chatRoomPage);
 
         return new ChatRoomListReadResponse(chatRooms, pageInfo);
     }

--- a/communication-service/src/main/java/com/example/communicationservice/type/MessageType.java
+++ b/communication-service/src/main/java/com/example/communicationservice/type/MessageType.java
@@ -4,79 +4,88 @@ import com.example.communicationservice.common.exception.ChatMessageException;
 import com.example.communicationservice.common.status.ResponseDtoStatus;
 import com.example.communicationservice.entity.ChatMessage;
 
+import java.util.function.Consumer;
+
 public enum MessageType {
 
     // 메시지 타입 1: 텍스트
-    TEXT {
-        @Override
-        public void validate(ChatMessage message) {
-            // 필수 필드 존재 여부 확인
-            if (message.getText() == null || message.getText().isBlank()) {
-                throw new ChatMessageException(ResponseDtoStatus.TEXT_MISSING);
-            }
-
-            // 필수 필드 상세 값 검증
-            if (message.getText().length() > TEXT_MAX_LENGTH) {
-                throw new ChatMessageException(ResponseDtoStatus.TOO_LONG_TEXT);
-            }
-
-            // 금지 필드 존재 여부 확인
-            if (message.getFile() != null) {
-                throw new ChatMessageException(ResponseDtoStatus.FILE_NOT_ALLOWED);
-            }
-        }
-    },
+    TEXT(message -> {
+        requireText(message);
+        validateTextLength(message);
+        forbidFile(message);
+    }),
 
     // 메시지 타입 2: 파일
-    FILE {
-        @Override
-        public void validate(ChatMessage message) {
-            // 필수 필드 존재 여부 확인
-            if (message.getFile() == null) {
-                throw new ChatMessageException(ResponseDtoStatus.FILE_MISSING);
-            }
-
-            // 필수 필드 존재 여부 확인
-            if (message.getFile().getKey() == null) {
-                throw new ChatMessageException(ResponseDtoStatus.FILE_KEY_MISSING);
-            }
-
-            // 금지 필드 존재 여부 확인
-            if (message.getText() != null && !message.getText().isBlank()) {
-                throw new ChatMessageException(ResponseDtoStatus.TEXT_NOT_ALLOWED);
-            }
-        }
-    },
+    FILE(message -> {
+        requireFile(message);
+        requireFileKey(message);
+        forbidText(message);
+    }),
 
     // 메시지 타입 3: 텍스트 + 파일
-    MIXED {
-        @Override
-        public void validate(ChatMessage message) {
-            // 필수 필드 존재 여부 확인
-            if (message.getText() == null || message.getText().isBlank()) {
-                throw new ChatMessageException(ResponseDtoStatus.TEXT_MISSING);
-            }
+    MIXED(message -> {
+        requireText(message);
+        validateTextLength(message);
+        requireFile(message);
+        requireFileKey(message);
+    });
 
-            // 필수 필드 존재 여부 확인
-            if (message.getFile() == null) {
-                throw new ChatMessageException(ResponseDtoStatus.FILE_MISSING);
-            }
+    private final Consumer<ChatMessage> validator;
 
-            // 필수 필드 존재 여부 확인
-            if (message.getFile().getKey() == null) {
-                throw new ChatMessageException(ResponseDtoStatus.FILE_KEY_MISSING);
-            }
+    MessageType(Consumer<ChatMessage> validator) {
+        this.validator = validator;
+    }
 
-            // 필수 필드 상세 값 검증
-            if (message.getText().length() > TEXT_MAX_LENGTH) {
-                throw new ChatMessageException(ResponseDtoStatus.TOO_LONG_TEXT);
-            }
+    public void validate(ChatMessage message) {
+        validator.accept(message);
+    }
+
+    // -----------------------------------------------------
+    //               공통 검증 로직 모듈화 영역
+    // -----------------------------------------------------
+
+    // 텍스트가 존재하는지 검증
+    private static void requireText(ChatMessage message) {
+        if (message.getText() == null || message.getText().isBlank()) {
+            throw new ChatMessageException(ResponseDtoStatus.TEXT_MISSING);
         }
-    };
+    }
 
-    public abstract void validate(ChatMessage message);
+    // 텍스트 길이가 최대 길이를 넘지 않는지 검증
+    private static void validateTextLength(ChatMessage message) {
+        if (message.getText().length() > TEXT_MAX_LENGTH) {
+            throw new ChatMessageException(ResponseDtoStatus.TOO_LONG_TEXT);
+        }
+    }
 
-    // 텍스트 최대 길이
+    // 파일이 존재하지 않는지 검증
+    private static void forbidFile(ChatMessage message) {
+        if (message.getFile() != null) {
+            throw new ChatMessageException(ResponseDtoStatus.FILE_NOT_ALLOWED);
+        }
+    }
+
+    // 파일이 존재하는지 검증
+    private static void requireFile(ChatMessage message) {
+        if (message.getFile() == null) {
+            throw new ChatMessageException(ResponseDtoStatus.FILE_MISSING);
+        }
+    }
+
+    // 파일 키가 존재하는지 검증
+    private static void requireFileKey(ChatMessage message) {
+        if (message.getFile().getKey() == null) {
+            throw new ChatMessageException(ResponseDtoStatus.FILE_KEY_MISSING);
+        }
+    }
+
+    // 텍스트가 존재하지 않는지 검증
+    private static void forbidText(ChatMessage message) {
+        if (message.getText() != null && !message.getText().isBlank()) {
+            throw new ChatMessageException(ResponseDtoStatus.TEXT_NOT_ALLOWED);
+        }
+    }
+
     private static final int TEXT_MAX_LENGTH = 1000;
 
 }

--- a/communication-service/src/main/java/com/example/communicationservice/type/MessageType.java
+++ b/communication-service/src/main/java/com/example/communicationservice/type/MessageType.java
@@ -1,0 +1,82 @@
+package com.example.communicationservice.type;
+
+import com.example.communicationservice.common.exception.ChatMessageException;
+import com.example.communicationservice.common.status.ResponseDtoStatus;
+import com.example.communicationservice.entity.ChatMessage;
+
+public enum MessageType {
+
+    // 메시지 타입 1: 텍스트
+    TEXT {
+        @Override
+        public void validate(ChatMessage message) {
+            // 필수 필드 존재 여부 확인
+            if (message.getText() == null || message.getText().isBlank()) {
+                throw new ChatMessageException(ResponseDtoStatus.TEXT_MISSING);
+            }
+
+            // 필수 필드 상세 값 검증
+            if (message.getText().length() > TEXT_MAX_LENGTH) {
+                throw new ChatMessageException(ResponseDtoStatus.TOO_LONG_TEXT);
+            }
+
+            // 금지 필드 존재 여부 확인
+            if (message.getFile() != null) {
+                throw new ChatMessageException(ResponseDtoStatus.FILE_NOT_ALLOWED);
+            }
+        }
+    },
+
+    // 메시지 타입 2: 파일
+    FILE {
+        @Override
+        public void validate(ChatMessage message) {
+            // 필수 필드 존재 여부 확인
+            if (message.getFile() == null) {
+                throw new ChatMessageException(ResponseDtoStatus.FILE_MISSING);
+            }
+
+            // 필수 필드 존재 여부 확인
+            if (message.getFile().getKey() == null) {
+                throw new ChatMessageException(ResponseDtoStatus.FILE_KEY_MISSING);
+            }
+
+            // 금지 필드 존재 여부 확인
+            if (message.getText() != null && !message.getText().isBlank()) {
+                throw new ChatMessageException(ResponseDtoStatus.TEXT_NOT_ALLOWED);
+            }
+        }
+    },
+
+    // 메시지 타입 3: 텍스트 + 파일
+    MIXED {
+        @Override
+        public void validate(ChatMessage message) {
+            // 필수 필드 존재 여부 확인
+            if (message.getText() == null || message.getText().isBlank()) {
+                throw new ChatMessageException(ResponseDtoStatus.TEXT_MISSING);
+            }
+
+            // 필수 필드 존재 여부 확인
+            if (message.getFile() == null) {
+                throw new ChatMessageException(ResponseDtoStatus.FILE_MISSING);
+            }
+
+            // 필수 필드 존재 여부 확인
+            if (message.getFile().getKey() == null) {
+                throw new ChatMessageException(ResponseDtoStatus.FILE_KEY_MISSING);
+            }
+
+            // 필수 필드 상세 값 검증
+            if (message.getText().length() > TEXT_MAX_LENGTH) {
+                throw new ChatMessageException(ResponseDtoStatus.TOO_LONG_TEXT);
+            }
+        }
+    };
+
+    public abstract void validate(ChatMessage message);
+
+    // 텍스트 최대 길이
+    private static final int TEXT_MAX_LENGTH = 1000;
+
+}

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
@@ -2,12 +2,14 @@ package com.example.communicationservice.service;
 
 import com.example.communicationservice.common.exception.ChatRoomException;
 import com.example.communicationservice.common.status.ResponseDtoStatus;
+import com.example.communicationservice.controller.dto.request.ChatMessageSendRequest;
 import com.example.communicationservice.controller.dto.response.ChatMessageListReadResponse;
 import com.example.communicationservice.controller.dto.response.ChatMessageSendResponse;
 import com.example.communicationservice.entity.ChatMessage;
 import com.example.communicationservice.entity.ChatRoom;
 import com.example.communicationservice.repository.ChatMessageRepository;
 import com.example.communicationservice.repository.ChatRoomRepository;
+import com.example.communicationservice.type.MessageType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -38,7 +40,7 @@ class ChatMessageServiceTest {
     private static final String MY_CODE = "USER_A";
     private static final String PARTNER_CODE = "USER_B";
     private static final String ROOM_NAME = "채팅방";
-    private static final String CHAT_CONTENT = "테스트 메시지입니다.";
+    private static final String CHAT_TEXT = "테스트 메시지입니다.";
 
     @InjectMocks
     private ChatMessageService chatMessageService;
@@ -130,8 +132,16 @@ class ChatMessageServiceTest {
         ChatMessage savedMessage = ChatMessage.builder()
             .roomId(ROOM_ID)
             .senderCode(MY_CODE)
-            .content(CHAT_CONTENT)
+            .type(MessageType.TEXT)
+            .text(CHAT_TEXT)
             .build();
+        ChatMessageSendRequest request = new ChatMessageSendRequest(
+            ROOM_ID,
+            MY_CODE,
+            MessageType.TEXT,
+            CHAT_TEXT,
+            null
+        );
 
         ReflectionTestUtils.setField(savedMessage, "id", messageId);
         ReflectionTestUtils.setField(savedMessage, "sentAt", Instant.now());
@@ -142,12 +152,12 @@ class ChatMessageServiceTest {
             .willReturn(savedMessage);
 
         // when
-        ChatMessageSendResponse response = chatMessageService.saveMessage(ROOM_ID, MY_CODE, CHAT_CONTENT);
+        ChatMessageSendResponse response = chatMessageService.saveMessage(request);
 
         // then
         assertThat(response).isNotNull();
         assertThat(response.messageId()).isEqualTo(messageId);
-        assertThat(response.content()).isEqualTo(CHAT_CONTENT);
+        assertThat(response.text()).isEqualTo(CHAT_TEXT);
 
         verify(chatRoomRepository, times(1)).findById(eq(ROOM_ID));
         verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
@@ -157,12 +167,20 @@ class ChatMessageServiceTest {
     @Test
     void 존재하지_않는_채팅방에_메시지_저장을_시도하면_예외가_발생한다() {
         // given
+        ChatMessageSendRequest request = new ChatMessageSendRequest(
+            ROOM_ID,
+            MY_CODE,
+            MessageType.TEXT,
+            CHAT_TEXT,
+            null
+        );
+
         given(chatRoomRepository.findById(any(String.class)))
             .willReturn(Optional.empty());
 
         // when & then
         ChatRoomException exception = assertThrows(ChatRoomException.class,
-            () -> chatMessageService.saveMessage(ROOM_ID, MY_CODE, CHAT_CONTENT));
+            () -> chatMessageService.saveMessage(request));
 
         assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_NOT_FOUND);
 
@@ -175,13 +193,20 @@ class ChatMessageServiceTest {
         // given
         String unauthorizedUser = "UNAUTHORIZED_USER";
         ChatRoom chatRoom = createMockChatRoom(List.of(MY_CODE, PARTNER_CODE));
+        ChatMessageSendRequest request = new ChatMessageSendRequest(
+            ROOM_ID,
+            unauthorizedUser,
+            MessageType.TEXT,
+            CHAT_TEXT,
+            null
+        );
 
         given(chatRoomRepository.findById(eq(ROOM_ID)))
             .willReturn(Optional.of(chatRoom));
 
         // when & then
         ChatRoomException exception = assertThrows(ChatRoomException.class,
-            () -> chatMessageService.saveMessage(ROOM_ID, unauthorizedUser, CHAT_CONTENT));
+            () -> chatMessageService.saveMessage(request));
 
         assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_FORBIDDEN);
 
@@ -200,11 +225,12 @@ class ChatMessageServiceTest {
         return chatRoom;
     }
 
-    private ChatMessage createMockMessage(String content, String senderCode) {
+    private ChatMessage createMockMessage(String text, String senderCode) {
         ChatMessage message = ChatMessage.builder()
             .roomId(ROOM_ID)
             .senderCode(senderCode)
-            .content(content)
+            .type(MessageType.TEXT)
+            .text(text)
             .build();
 
         ReflectionTestUtils.setField(message, "id", "msg-" + Instant.now().getNano());

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatRoomServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatRoomServiceTest.java
@@ -4,6 +4,7 @@ import com.example.communicationservice.client.MemberServiceClient;
 import com.example.communicationservice.client.dto.MemberExistOutput;
 import com.example.communicationservice.common.exception.ChatRoomException;
 import com.example.communicationservice.common.status.ResponseDtoStatus;
+import com.example.communicationservice.controller.dto.request.ChatRoomCreateRequest;
 import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
 import com.example.communicationservice.controller.dto.response.ChatRoomListReadResponse;
 import com.example.communicationservice.controller.dto.response.PageInfo;
@@ -65,13 +66,15 @@ class ChatRoomServiceTest {
             .memberCodes(memberCodes)
             .build();
 
+        ChatRoomCreateRequest request = new ChatRoomCreateRequest(roomName, memberCodes);
+
         ReflectionTestUtils.setField(savedChatRoom, "id", roomId); // 리플렉션으로 아이디 추가
 
         given(chatRoomRepository.save(any(ChatRoom.class)))
             .willReturn(savedChatRoom);
 
         // when
-        ChatRoomCreateResponse response = chatRoomService.createChatRoom(roomName, memberCodes, myCode);
+        ChatRoomCreateResponse response = chatRoomService.createChatRoom(request, myCode);
 
         // then
         assertThat(response).isNotNull();
@@ -84,11 +87,13 @@ class ChatRoomServiceTest {
     void 채팅방_참여자_수가_2명이_아니면_채팅방_생성에_실패한다() {
         // given
         String myCode = "USER_A";
+        String roomName = "CHAT_ROOM";
         List<String> memberCodes = List.of(myCode);
+        ChatRoomCreateRequest request = new ChatRoomCreateRequest(roomName, memberCodes);
 
         // when & then
         ChatRoomException exception = assertThrows(ChatRoomException.class,
-            () -> chatRoomService.createChatRoom("채팅방", memberCodes, myCode));
+            () -> chatRoomService.createChatRoom(request, myCode));
 
         assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_INVALID_MEMBER_COUNT);
     }
@@ -97,11 +102,13 @@ class ChatRoomServiceTest {
     void 채팅방_생성_요청자가_채팅방_참여자_목록에_없으면_채팅방_생성에_실패한다() {
         // given
         String myCode = "USER_A";
+        String roomName = "CHAT_ROOM";
         List<String> memberCodes = List.of("USER_B", "USER_C");
+        ChatRoomCreateRequest request = new ChatRoomCreateRequest(roomName, memberCodes);
 
         // when & then
         ChatRoomException exception = assertThrows(ChatRoomException.class,
-            () -> chatRoomService.createChatRoom("채팅방", memberCodes, myCode));
+            () -> chatRoomService.createChatRoom(request, myCode));
 
         assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_NOT_INCLUDE_SELF);
     }
@@ -111,7 +118,9 @@ class ChatRoomServiceTest {
         // given
         String myCode = "USER_A";
         String unknownCode = "USER_UNKNOWN";
+        String roomName = "CHAT_ROOM";
         List<String> memberCodes = List.of(myCode, unknownCode);
+        ChatRoomCreateRequest request = new ChatRoomCreateRequest(roomName, memberCodes);
 
         MemberExistOutput mockOutput = new MemberExistOutput(List.of(myCode), List.of(unknownCode));
 
@@ -120,7 +129,7 @@ class ChatRoomServiceTest {
 
         // when & then
         ChatRoomException exception = assertThrows(ChatRoomException.class,
-            () -> chatRoomService.createChatRoom("채팅방", memberCodes, myCode));
+            () -> chatRoomService.createChatRoom(request, myCode));
 
         assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_INVALID_MEMBER);
     }
@@ -128,7 +137,9 @@ class ChatRoomServiceTest {
     @Test
     void 채팅방_참여자_사이에_이미_채팅방이_존재하면_채팅방_생성에_실패한다() {
         // given
+        String roomName = "CHAT_ROOM";
         List<String> memberCodes = List.of("USER_A", "USER_B");
+        ChatRoomCreateRequest request = new ChatRoomCreateRequest(roomName, memberCodes);
 
         MemberExistOutput mockOutput = new MemberExistOutput(memberCodes, List.of());
 
@@ -140,7 +151,7 @@ class ChatRoomServiceTest {
 
         // when & then
         ChatRoomException exception = assertThrows(ChatRoomException.class,
-            () -> chatRoomService.createChatRoom("채팅방", memberCodes, "USER_A"));
+            () -> chatRoomService.createChatRoom(request, "USER_A"));
 
         assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_ALREADY_EXISTS);
     }


### PR DESCRIPTION
## 🐛 관련 이슈
 <!-- Closes #{이슈-번호} 형태로 작성하세요 (ex: Closes #134) -->
Closes #134 

## 📌 목적
- 채팅 메시지에 파일(`이미지`, `PDF`)을 포함할 수 있게 변경합니다.

## ✅ 변경 사항
### 1️⃣ [메시지 타입 추가](https://github.com/prgrms-be-adv-devcourse/beadv1_1_hexagon_BE/commit/b0d3dd3a10106c0cf41735561d18fb8388c50b18)

기존에는 메시지 타입이 별도로 존재하지 않았기 때문에, `TEXT`, `FILE`, `MIXED` enum을 추가했습니다.

- `TEXT`: 텍스트 메시지

- `FILE`: 파일 메시지

- `MIXED`: 텍스트 + 파일 메시지

<br>

### 2️⃣ [메시지 타입별 유효성 검증](https://github.com/prgrms-be-adv-devcourse/beadv1_1_hexagon_BE/blob/b0d3dd3a10106c0cf41735561d18fb8388c50b18/communication-service/src/main/java/com/example/communicationservice/type/MessageType.java)

현재 채팅 메시지 엔티티는 아래와 같이 구성되어 있습니다. 

```java
public class ChatMessage {

    @Id
    private String id; // MongoDB의 PK, ObjectId와 매핑

    private String roomId;

    private String senderCode;

    private MessageType type;

    private String text;

    private File file;

    @CreatedDate
    private Instant sentAt; // 전송된 시간

    ...
}
```
<br>

이때 메시지 타입에 따라 필드의 null 가능 여부가 달라집니다.

- `TEXT`: `text`는 `not null`, `file`은 `null`

- `FILE`: `text`는 `null`, `file`은 `not null`

- `MIXED`: `text`도 `not null`, `file`도 `not null`

<br>

이러한 유효성 검증은 단일 `DTO validation`만으로는 한계가 있기 때문에 `추상 메서드`를 활용했습니다.

1. 메시지 타입 enum 내부에 추상 메서드 `validate`를 정의합니다.

2. 각 enum 상수(`TEXT`, `FILE`, `MIXED`)가 해당 타입에 맞는 검증 로직을 오버라이드합니다.

3. 채팅 메시지 엔티티 생성 시 생성자 내에서 `validate`를 호출해 유효성을 검증합니다.

<br>

이 방식은 다음과 같은 장점이 있습니다.

- 타입별 검증 로직이 enum 내부에 응집되어 있어 `가독성`이 향상됩니다.

- 서비스 레이어에서 검증 분기를 수행할 필요가 없기 때문에 `비즈니스 로직이 단순`해집니다.

- 새로운 메시지 타입이 추가될 경우 새 enum 상수를 정의하고 검증 로직을 오버라이드하면 되므로 `확장성`이 증가합니다.

<br>

### 🛠️ [메시지 타입별 유효성 검증 리팩토링](https://github.com/prgrms-be-adv-devcourse/beadv1_1_hexagon_BE/pull/174/commits/f10b81bb5cd0b1cb2557ecba5ae5d18e53c40e4f)

초기 구현은 각 enum 상수(`TEXT`, `FILE`, `MIXED`)가  `validate`를 오버라이드하는 방식이었습니다.

그러나 중복되는 검증 코드가 각 타입에 흩어져 있는 문제가 있었기 때문에,

인수님(@ZZAMBAs)의 피드백을 반영하여 함수형 기반의 `Consumer` 구조로 리팩토링했습니다.

1. 각 메시지 타입은 자신이 필요로 하는 검증 조합을 `Consumer` 체인 형태로 정의합니다.

2. 공통적으로 사용되는 세부 검증 로직을 enum 아래 정적 메서드로 모듈화합니다.

3. `validate`는 단순히 해당 타입의 `validator`를 호출하는 역할만 하도록 축소했습니다.

<br>

리팩토링된 예시는 아래와 같습니다.

```java
TEXT(message -> {
    requireText(message);
    validateTextLength(message);
    forbidFile(message);
}),
FILE(message -> {
    requireFile(message);
    requireFileKey(message);
    forbidText(message);
}),
MIXED(message -> {
    requireText(message);
    validateTextLength(message);
    requireFile(message);
    requireFileKey(message);
});
```

<br>

이 방식으로 변경하면서 다음과 같은 효과가 있었습니다.

- 공통 검증 로직이 한 곳에 모여 정리되어 있어 `유지보수성`이 크게 향상되었습니다.

- 각 타입이 필요로 하는 검증 흐름을 순서대로 나열하는 구성 방식이 되어 `가독성`이 개선되었습니다.

- 새로운 메시지 타입이 추가될 경우 필요한 검증 메서드를 조합하면 되므로 `확장`과 `변경`이 훨씬 유연해졌습니다.

<br>

### 3️⃣ [DTO <-> 엔티티 변환 mapper 추가](https://github.com/prgrms-be-adv-devcourse/beadv1_1_hexagon_BE/commit/781eddb26f39f17ea7c5397fc72e761ae0141e73)

기존에는 DTO 내에 `정적 팩토리 메서드`를 구현해 DTO <-> 엔티티 변환을 수행했기 때문에, DTO가 엔티티를 의존하는 문제가 있었습니다.

```java
public record ChatRoomCreateResponse(
    String id
) {
    public static ChatRoomCreateResponse from(ChatRoom chatRoom) { // 엔티티 의존
        return new ChatRoomCreateResponse(chatRoom.getId());
    }
}
```

<br>

따라서 레이어 간 결합도를 낮추기 위해 별도의 mapper를 구현했습니다.

```java
// dto와 entity 사이의 변환 로직 전담
public abstract class ChatMapper {

    private ChatMapper() {} // 인스턴스화 방지

    // ------------------ ChatMessage ------------------

    public static ChatMessage toEntity(ChatMessageSendRequest request) {
        return ChatMessage.builder()
            .roomId(request.roomId())
            .senderCode(request.senderCode())
            .type(request.type())
            .text(request.text())
            .file(request.file() != null ? toEntity(request.file()) : null)
            .build();
    }

    ...
}
```

## 🧪 테스트 방법
기존 서비스 단위 테스트 코드에 변경 사항을 반영했습니다.

## 📎 참고 사항
- 관련 이슈 번호 : #134 

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [x] 이슈 번호를 입력 했나요?
- [x] 코드 컨벤션을 모두 지켰나요?
- [x] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
