### PR TITLE
feat(contract): 컨트롤러에서 처리하는 전역 예외 핸들러 추가

### DIFF
--- a/contract-service/src/main/java/com/example/contractservice/common/controller/GlobalExceptionHandler.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/controller/GlobalExceptionHandler.java
@@ -1,0 +1,51 @@
+package com.example.contractservice.common.controller;
+
+import com.example.contractservice.common.util.StringUtil;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.hexagon.core.dto.ResponseDto;
+import org.hexagon.core.dto.Empty;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseDto<Empty> handle(MethodArgumentNotValidException e) {
+        String allExceptionMessages = e.getBindingResult().getAllErrors().stream().map(err -> err.getDefaultMessage())
+                .collect(Collectors.joining(" | "));
+
+        String message = StringUtil.format("입력 값이 올바르지 않습니다. {}", allExceptionMessages);
+
+        return new ResponseDto<>(4999, HttpStatus.BAD_REQUEST.value(), message, Empty.getInstance());
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseDto<Empty> handle(BindException e) {
+        String bindingFailObjects = e.getBindingResult().getAllErrors().stream().map(err -> err.getObjectName())
+                .collect(Collectors.joining(", "));
+
+        String message = StringUtil.format("잘못된 타입의 입력이 존재합니다. 다음을 확인하십시오: {}", bindingFailObjects);
+
+        return new ResponseDto<>(4999, HttpStatus.BAD_REQUEST.value(), message, Empty.getInstance());
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseDto<Empty> handle() {
+        String message = "잘못된 타입의 입력이 있거나 입력 구조가 잘못되었습니다.";
+
+        return new ResponseDto<>(4999, HttpStatus.BAD_REQUEST.value(), message, Empty.getInstance());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseDto<Empty> handle(Exception e) {
+        log.error("알 수 없는 예외 발생. 빠른 확인 필요!", e);
+
+        return ResponseDto.fail();
+    }
+}


### PR DESCRIPTION
## 🐛 관련 이슈
 <!-- Closes #{이슈-번호} 형태로 작성하세요 (ex: Closes #134) -->
Closes #169 

## 📌 목적
범용적으로 발생할 수 있는 API 요청 에러 처리와 예상치 못한 예외에 대한 처리를 진행하는 GlobalExceptionHandler를 구현합니다.

## ✅ 변경 사항
### 전역적으로 발생할 수 있는 예외 처리
다음이 발생할 수 있습니다.
* `MethodArgumentNotValidException`: Spring MVC가 검증 어노테이션에 정의된 검증 처리로 보내는 예외입니다. 이를테면 `@Min(0)` 인 필드에 -1을 넣는 것이 그 예이고 이 때 해당 예외가 일어납니다. 이를 처리합니다.
* `BindException`: `@ModelAttribute` 또는 `@PathVariable` 등에서 발생할 수 있는 타입 매칭 예외를 잡습니다.
* `HttpMessageNotReadableException`: 클라이언트 측이 body 값을 잘못된 구조로 보내거나 각 값의 타입이 잘못되었을 경우 나타날 수 있습니다. 
* `Exception`: 그 외 알 수 없는 에러입니다. 이를 처리하면 반드시 error 로그와 스택 트레이스를 남깁니다.

## 🧪 테스트 방법
직접 API를 이상하게 보내보면 되며, 실제로 테스트 하였습니다.

## 📎 참고 사항
- 관련 이슈 번호 : #169 

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [ ] 이슈 번호를 입력 했나요?
- [ ] 코드 컨벤션을 모두 지켰나요?
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
