### PR TITLE
feat(chat): 파일 메시지 전송 기능 구현

### DIFF
--- a/communication-service/src/main/java/com/example/communicationservice/client/MemberServiceClient.java
+++ b/communication-service/src/main/java/com/example/communicationservice/client/MemberServiceClient.java
@@ -1,6 +1,6 @@
 package com.example.communicationservice.client;
 
-import com.example.communicationservice.client.dto.MemberExistOutput;
+import com.example.communicationservice.client.dto.output.MemberExistOutput;
 import org.hexagon.core.dto.ResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/communication-service/src/main/java/com/example/communicationservice/client/S3ServiceClient.java
+++ b/communication-service/src/main/java/com/example/communicationservice/client/S3ServiceClient.java
@@ -1,6 +1,8 @@
 package com.example.communicationservice.client;
 
+import com.example.communicationservice.client.dto.input.FileDownloadUrlGenerateInput;
 import com.example.communicationservice.client.dto.input.FileUploadUrlGenerateInput;
+import com.example.communicationservice.client.dto.output.FileDownloadUrlListGenerateOutput;
 import com.example.communicationservice.client.dto.output.FileUploadUrlGenerateOutput;
 import org.hexagon.core.dto.ResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -16,5 +18,8 @@ public interface S3ServiceClient {
 
     @PostMapping("/upload-url")
     ResponseDto<FileUploadUrlGenerateOutput> generateUploadUrl(@RequestBody FileUploadUrlGenerateInput input);
+
+    @PostMapping("/download-url/key")
+    ResponseDto<FileDownloadUrlListGenerateOutput> generateDownloadUrl(@RequestBody FileDownloadUrlGenerateInput input);
 
 }

--- a/communication-service/src/main/java/com/example/communicationservice/client/S3ServiceClient.java
+++ b/communication-service/src/main/java/com/example/communicationservice/client/S3ServiceClient.java
@@ -1,0 +1,20 @@
+package com.example.communicationservice.client;
+
+import com.example.communicationservice.client.dto.input.FileUploadUrlGenerateInput;
+import com.example.communicationservice.client.dto.output.FileUploadUrlGenerateOutput;
+import org.hexagon.core.dto.ResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+// name: 호출 대상 서비스 이름, path: 기본 경로
+@FeignClient(
+    name = "s3-service",
+    path = "/internal/s3"
+)
+public interface S3ServiceClient {
+
+    @PostMapping("/upload-url")
+    ResponseDto<FileUploadUrlGenerateOutput> generateUploadUrl(@RequestBody FileUploadUrlGenerateInput input);
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/client/dto/input/FileDownloadUrlGenerateInput.java
+++ b/communication-service/src/main/java/com/example/communicationservice/client/dto/input/FileDownloadUrlGenerateInput.java
@@ -1,0 +1,8 @@
+package com.example.communicationservice.client.dto.input;
+
+import java.util.List;
+
+public record FileDownloadUrlGenerateInput(
+    List<String> keys
+) {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/client/dto/input/FileUploadUrlGenerateInput.java
+++ b/communication-service/src/main/java/com/example/communicationservice/client/dto/input/FileUploadUrlGenerateInput.java
@@ -1,7 +1,9 @@
 package com.example.communicationservice.client.dto.input;
 
+import org.hexagon.core.vo.ServiceName;
+
 public record FileUploadUrlGenerateInput(
-    String serviceName,
+    ServiceName serviceName,
     String fileName,
     String contentType
 ) {

--- a/communication-service/src/main/java/com/example/communicationservice/client/dto/input/FileUploadUrlGenerateInput.java
+++ b/communication-service/src/main/java/com/example/communicationservice/client/dto/input/FileUploadUrlGenerateInput.java
@@ -1,0 +1,8 @@
+package com.example.communicationservice.client.dto.input;
+
+public record FileUploadUrlGenerateInput(
+    String serviceName,
+    String fileName,
+    String contentType
+) {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/client/dto/output/FileDownloadUrlGenerateOutput.java
+++ b/communication-service/src/main/java/com/example/communicationservice/client/dto/output/FileDownloadUrlGenerateOutput.java
@@ -1,0 +1,10 @@
+package com.example.communicationservice.client.dto.output;
+
+import org.hexagon.core.vo.FileType;
+
+public record FileDownloadUrlGenerateOutput(
+    String key,
+    String queryString,
+    FileType fileType
+) {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/client/dto/output/FileDownloadUrlListGenerateOutput.java
+++ b/communication-service/src/main/java/com/example/communicationservice/client/dto/output/FileDownloadUrlListGenerateOutput.java
@@ -1,0 +1,8 @@
+package com.example.communicationservice.client.dto.output;
+
+import java.util.List;
+
+public record FileDownloadUrlListGenerateOutput(
+    List<FileDownloadUrlGenerateOutput> urls
+) {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/client/dto/output/FileUploadUrlGenerateOutput.java
+++ b/communication-service/src/main/java/com/example/communicationservice/client/dto/output/FileUploadUrlGenerateOutput.java
@@ -1,0 +1,7 @@
+package com.example.communicationservice.client.dto.output;
+
+public record FileUploadUrlGenerateOutput(
+    String key,
+    String queryString
+) {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/client/dto/output/MemberExistOutput.java
+++ b/communication-service/src/main/java/com/example/communicationservice/client/dto/output/MemberExistOutput.java
@@ -1,4 +1,4 @@
-package com.example.communicationservice.client.dto;
+package com.example.communicationservice.client.dto.output;
 
 import java.util.List;
 

--- a/communication-service/src/main/java/com/example/communicationservice/controller/ChatFileController.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/ChatFileController.java
@@ -1,0 +1,33 @@
+package com.example.communicationservice.controller;
+
+import com.example.communicationservice.controller.dto.request.ChatFileUploadUrlGenerateRequest;
+import com.example.communicationservice.controller.dto.response.ChatFileUploadUrlGenerateResponse;
+import com.example.communicationservice.service.ChatFileService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.hexagon.core.dto.ResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chatrooms/{room-id}/files")
+public class ChatFileController {
+
+    private final ChatFileService chatFileService;
+
+    // 파일 업로드 URL 생성 API
+    @PostMapping("/upload-url")
+    public ResponseEntity<ResponseDto<ChatFileUploadUrlGenerateResponse>> generateUploadUrl(
+        @PathVariable(name = "room-id") String roomId,
+        @RequestHeader(name = "X-CODE") String senderCode,
+        @Valid @RequestBody ChatFileUploadUrlGenerateRequest request
+    ) {
+        ChatFileUploadUrlGenerateResponse response = chatFileService.generateUploadUrl(roomId, senderCode, request);
+
+        return ResponseEntity
+            .ok()
+            .body(ResponseDto.success(response));
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/ChatFileController.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/ChatFileController.java
@@ -1,5 +1,6 @@
 package com.example.communicationservice.controller;
 
+import com.example.communicationservice.controller.api.ChatFileControllerApi;
 import com.example.communicationservice.controller.dto.request.ChatFileUploadUrlGenerateRequest;
 import com.example.communicationservice.controller.dto.response.ChatFileUploadUrlGenerateResponse;
 import com.example.communicationservice.service.ChatFileService;
@@ -12,12 +13,13 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chatrooms/{room-id}/files")
-public class ChatFileController {
+public class ChatFileController implements ChatFileControllerApi {
 
     private final ChatFileService chatFileService;
 
     // 파일 업로드 URL 생성 API
     @PostMapping("/upload-url")
+    @Override
     public ResponseEntity<ResponseDto<ChatFileUploadUrlGenerateResponse>> generateUploadUrl(
         @PathVariable(name = "room-id") String roomId,
         @RequestHeader(name = "X-CODE") String senderCode,

--- a/communication-service/src/main/java/com/example/communicationservice/controller/ChatMessageController.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/ChatMessageController.java
@@ -25,14 +25,14 @@ public class ChatMessageController {
     private final ChatMessageService chatMessageService;
 
     /**
-     * 메시지 수신 처리
-     * 1. 채팅방 참여자 인가
-     * 2. DB 저장
-     * 3. 해당 토픽 구독자에게 메시지 전송
+     * 메시지 수신 처리 <br>
+     * 1. 채팅방 참여자 인가 <br>
+     * 2. DB 저장 <br>
+     * 3. 해당 토픽 구독자에게 메시지 전송 <br>
      */
     @MessageMapping("chat.send")
     public void handleChatMessage(@Valid @Payload ChatMessageSendRequest request) {
-        ChatMessageSendResponse response = chatMessageService.saveMessage(request);
+        ChatMessageSendResponse response = chatMessageService.sendMessage(request);
 
         String destinationPrefix = "/queue/room/";
         messagingTemplate.convertAndSend(destinationPrefix + request.roomId(), response);

--- a/communication-service/src/main/java/com/example/communicationservice/controller/api/ChatFileControllerApi.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/api/ChatFileControllerApi.java
@@ -1,0 +1,52 @@
+package com.example.communicationservice.controller.api;
+
+import com.example.communicationservice.controller.dto.request.ChatFileUploadUrlGenerateRequest;
+import com.example.communicationservice.controller.dto.response.ChatFileUploadUrlGenerateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.hexagon.core.dto.ResponseDto;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "ChatFile API", description = "채팅 메시지에 포함된 파일 관리")
+public interface ChatFileControllerApi {
+
+    @Operation(
+        summary = "파일 업로드 URL 생성",
+        description = "특정 채팅방에 파일이 포함된 메시지를 전송하기 위해 파일 업로드 URL을 생성합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "파일 업로드 URL 생성 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    ResponseEntity<ResponseDto<ChatFileUploadUrlGenerateResponse>> generateUploadUrl(
+        @Parameter(
+            name = "room-id",
+            description = "채팅방 아이디",
+            required = true,
+            in = ParameterIn.PATH,
+            example = "651f7c8b9a1d4c6f8b2e3d1a"
+        )
+        String roomId,
+
+        @Parameter(
+            name = "X-CODE",
+            description = "현재 로그인한 회원 코드",
+            required = true,
+            in = ParameterIn.HEADER,
+            example = "abc-12345-ABC"
+        )
+        String senderCode,
+
+        @RequestBody(
+            description = "파일 업로드 URL 생성 요청 DTO",
+            required = true
+        )
+        ChatFileUploadUrlGenerateRequest request
+    );
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatFileSendRequest.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatFileSendRequest.java
@@ -1,0 +1,6 @@
+package com.example.communicationservice.controller.dto.request;
+
+public record ChatFileSendRequest(
+    String key
+) {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatFileUploadUrlGenerateRequest.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatFileUploadUrlGenerateRequest.java
@@ -1,0 +1,19 @@
+package com.example.communicationservice.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ChatFileUploadUrlGenerateRequest(
+
+    @NotBlank(message = "파일 이름은 필수입니다.")
+    String fileName,
+
+    @NotBlank(message = "파일 타입은 필수입니다.")
+    @Pattern(
+        regexp = "^(image/(jpeg|png|webp)|application/pdf)$", // 이미지, PDF만 가능
+        message = "허용되지 않는 파일 타입입니다."
+    )
+    String contentType
+
+) {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatMessageSendRequest.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/request/ChatMessageSendRequest.java
@@ -1,6 +1,5 @@
 package com.example.communicationservice.controller.dto.request;
 
-import com.example.communicationservice.controller.dto.FileInfo;
 import com.example.communicationservice.type.MessageType;
 import jakarta.validation.constraints.NotNull;
 
@@ -17,7 +16,7 @@ public record ChatMessageSendRequest(
 
     String text,
 
-    FileInfo file
+    ChatFileSendRequest file
 
 ) {
 }

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatFileSendResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatFileSendResponse.java
@@ -1,0 +1,10 @@
+package com.example.communicationservice.controller.dto.response;
+
+import org.hexagon.core.vo.FileType;
+
+public record ChatFileSendResponse(
+    String key,
+    String queryString, // pre-signed download URL 구성 요소
+    FileType fileType
+) {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatFileUploadUrlGenerateResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatFileUploadUrlGenerateResponse.java
@@ -1,0 +1,7 @@
+package com.example.communicationservice.controller.dto.response;
+
+public record ChatFileUploadUrlGenerateResponse(
+    String key, // pre-signed upload URL 구성 요소
+    String queryString // pre-signed upload URL 구성 요소
+) {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageSendResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageSendResponse.java
@@ -1,6 +1,5 @@
 package com.example.communicationservice.controller.dto.response;
 
-import com.example.communicationservice.controller.dto.FileInfo;
 import com.example.communicationservice.type.MessageType;
 
 import java.time.Instant;
@@ -11,7 +10,7 @@ public record ChatMessageSendResponse(
     String senderCode,
     MessageType type,
     String text,
-    FileInfo file,
+    ChatFileSendResponse file,
     Instant sentAt
 ) {
 }

--- a/communication-service/src/main/java/com/example/communicationservice/mapper/ChatMapper.java
+++ b/communication-service/src/main/java/com/example/communicationservice/mapper/ChatMapper.java
@@ -1,16 +1,13 @@
 package com.example.communicationservice.mapper;
 
-import com.example.communicationservice.client.dto.output.FileDownloadUrlGenerateOutput;
 import com.example.communicationservice.client.dto.output.FileDownloadUrlListGenerateOutput;
-import com.example.communicationservice.client.dto.output.FileUploadUrlGenerateOutput;
-import com.example.communicationservice.controller.dto.FileInfo;
-import com.example.communicationservice.controller.dto.request.ChatFileSendRequest;
 import com.example.communicationservice.controller.dto.request.ChatMessageSendRequest;
-import com.example.communicationservice.controller.dto.response.*;
+import com.example.communicationservice.controller.dto.response.ChatMessageReadResponse;
+import com.example.communicationservice.controller.dto.response.ChatMessageSendResponse;
+import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
+import com.example.communicationservice.controller.dto.response.ChatRoomReadResponse;
 import com.example.communicationservice.entity.ChatMessage;
 import com.example.communicationservice.entity.ChatRoom;
-import com.example.communicationservice.entity.File;
-import org.springframework.data.domain.Page;
 
 // dto <-> entity 또는 dto <-> dto 변환 로직 전담
 public abstract class ChatMapper {
@@ -25,7 +22,7 @@ public abstract class ChatMapper {
             .senderCode(request.senderCode())
             .type(request.type())
             .text(request.text())
-            .file(request.file() != null ? toEntity(request.file()) : null)
+            .file(request.file() != null ? FileMapper.toEntity(request.file()) : null)
             .build();
     }
 
@@ -35,7 +32,7 @@ public abstract class ChatMapper {
             message.getSenderCode(),
             message.getType(),
             message.getText(),
-            from(message.getFile()),
+            FileMapper.from(message.getFile()),
             message.getSentAt()
         );
     }
@@ -50,7 +47,7 @@ public abstract class ChatMapper {
             message.getSenderCode(),
             message.getType(),
             message.getText(),
-            output != null ? from(output.urls().get(0)) : null,
+            output != null ? FileMapper.from(output.urls().get(0)) : null,
             message.getSentAt()
         );
     }
@@ -66,53 +63,6 @@ public abstract class ChatMapper {
             chatRoom.getId(),
             chatRoom.getName(),
             chatRoom.getUpdatedAt()
-        );
-    }
-
-    // ------------------ Paging ------------------
-
-    public static PageInfo toPageInfo(Page<?> page) {
-        return new PageInfo(
-            page.getNumber(),
-            page.getSize(),
-            page.getTotalElements(),
-            page.getTotalPages(),
-            page.hasNext()
-        );
-    }
-
-    // ------------------ File ------------------
-
-    public static FileInfo from(File file) {
-        if (file == null) {
-            return null;
-        }
-
-        return new FileInfo(file.getKey());
-    }
-
-    public static File toEntity(ChatFileSendRequest request) {
-        if (request == null) {
-            return null;
-        }
-
-        return File.builder()
-            .key(request.key())
-            .build();
-    }
-
-    public static ChatFileUploadUrlGenerateResponse from(FileUploadUrlGenerateOutput output) {
-        return new ChatFileUploadUrlGenerateResponse(
-            output.key(),
-            output.queryString()
-        );
-    }
-
-    public static ChatFileSendResponse from(FileDownloadUrlGenerateOutput output) {
-        return new ChatFileSendResponse(
-            output.key(),
-            output.queryString(),
-            output.fileType()
         );
     }
 

--- a/communication-service/src/main/java/com/example/communicationservice/mapper/ChatMapper.java
+++ b/communication-service/src/main/java/com/example/communicationservice/mapper/ChatMapper.java
@@ -1,7 +1,10 @@
 package com.example.communicationservice.mapper;
 
+import com.example.communicationservice.client.dto.output.FileDownloadUrlGenerateOutput;
+import com.example.communicationservice.client.dto.output.FileDownloadUrlListGenerateOutput;
 import com.example.communicationservice.client.dto.output.FileUploadUrlGenerateOutput;
 import com.example.communicationservice.controller.dto.FileInfo;
+import com.example.communicationservice.controller.dto.request.ChatFileSendRequest;
 import com.example.communicationservice.controller.dto.request.ChatMessageSendRequest;
 import com.example.communicationservice.controller.dto.response.*;
 import com.example.communicationservice.entity.ChatMessage;
@@ -37,14 +40,17 @@ public abstract class ChatMapper {
         );
     }
 
-    public static ChatMessageSendResponse toSendResponse(ChatMessage message) {
+    public static ChatMessageSendResponse toSendResponse(
+        ChatMessage message,
+        FileDownloadUrlListGenerateOutput output
+    ) {
         return new ChatMessageSendResponse(
             message.getId(),
             message.getRoomId(),
             message.getSenderCode(),
             message.getType(),
             message.getText(),
-            from(message.getFile()),
+            output != null ? from(output.urls().get(0)) : null,
             message.getSentAt()
         );
     }
@@ -85,13 +91,13 @@ public abstract class ChatMapper {
         return new FileInfo(file.getKey());
     }
 
-    public static File toEntity(FileInfo fileInfo) {
-        if (fileInfo == null) {
+    public static File toEntity(ChatFileSendRequest request) {
+        if (request == null) {
             return null;
         }
 
         return File.builder()
-            .key(fileInfo.key())
+            .key(request.key())
             .build();
     }
 
@@ -99,6 +105,14 @@ public abstract class ChatMapper {
         return new ChatFileUploadUrlGenerateResponse(
             output.key(),
             output.queryString()
+        );
+    }
+
+    public static ChatFileSendResponse from(FileDownloadUrlGenerateOutput output) {
+        return new ChatFileSendResponse(
+            output.key(),
+            output.queryString(),
+            output.fileType()
         );
     }
 

--- a/communication-service/src/main/java/com/example/communicationservice/mapper/ChatMapper.java
+++ b/communication-service/src/main/java/com/example/communicationservice/mapper/ChatMapper.java
@@ -1,5 +1,6 @@
 package com.example.communicationservice.mapper;
 
+import com.example.communicationservice.client.dto.output.FileUploadUrlGenerateOutput;
 import com.example.communicationservice.controller.dto.FileInfo;
 import com.example.communicationservice.controller.dto.request.ChatMessageSendRequest;
 import com.example.communicationservice.controller.dto.response.*;
@@ -8,7 +9,7 @@ import com.example.communicationservice.entity.ChatRoom;
 import com.example.communicationservice.entity.File;
 import org.springframework.data.domain.Page;
 
-// dto와 entity 사이의 변환 로직 전담
+// dto <-> entity 또는 dto <-> dto 변환 로직 전담
 public abstract class ChatMapper {
 
     private ChatMapper() {} // 인스턴스화 방지
@@ -92,6 +93,13 @@ public abstract class ChatMapper {
         return File.builder()
             .key(fileInfo.key())
             .build();
+    }
+
+    public static ChatFileUploadUrlGenerateResponse from(FileUploadUrlGenerateOutput output) {
+        return new ChatFileUploadUrlGenerateResponse(
+            output.key(),
+            output.queryString()
+        );
     }
 
 }

--- a/communication-service/src/main/java/com/example/communicationservice/mapper/FileMapper.java
+++ b/communication-service/src/main/java/com/example/communicationservice/mapper/FileMapper.java
@@ -1,0 +1,49 @@
+package com.example.communicationservice.mapper;
+
+import com.example.communicationservice.client.dto.output.FileDownloadUrlGenerateOutput;
+import com.example.communicationservice.client.dto.output.FileUploadUrlGenerateOutput;
+import com.example.communicationservice.controller.dto.FileInfo;
+import com.example.communicationservice.controller.dto.request.ChatFileSendRequest;
+import com.example.communicationservice.controller.dto.response.ChatFileSendResponse;
+import com.example.communicationservice.controller.dto.response.ChatFileUploadUrlGenerateResponse;
+import com.example.communicationservice.entity.File;
+
+// dto <-> entity 또는 dto <-> dto 변환 로직 전담
+public abstract class FileMapper {
+
+    private FileMapper() {} // 인스턴스화 방지
+
+    public static FileInfo from(File file) {
+        if (file == null) {
+            return null;
+        }
+
+        return new FileInfo(file.getKey());
+    }
+
+    public static File toEntity(ChatFileSendRequest request) {
+        if (request == null) {
+            return null;
+        }
+
+        return File.builder()
+            .key(request.key())
+            .build();
+    }
+
+    public static ChatFileUploadUrlGenerateResponse from(FileUploadUrlGenerateOutput output) {
+        return new ChatFileUploadUrlGenerateResponse(
+            output.key(),
+            output.queryString()
+        );
+    }
+
+    public static ChatFileSendResponse from(FileDownloadUrlGenerateOutput output) {
+        return new ChatFileSendResponse(
+            output.key(),
+            output.queryString(),
+            output.fileType()
+        );
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/mapper/PageMapper.java
+++ b/communication-service/src/main/java/com/example/communicationservice/mapper/PageMapper.java
@@ -1,0 +1,21 @@
+package com.example.communicationservice.mapper;
+
+import com.example.communicationservice.controller.dto.response.PageInfo;
+import org.springframework.data.domain.Page;
+
+// dto <-> entity 변환 로직 전담
+public abstract class PageMapper {
+
+    private PageMapper() {} // 인스턴스화 방지
+
+    public static PageInfo toPageInfo(Page<?> page) {
+        return new PageInfo(
+            page.getNumber(),
+            page.getSize(),
+            page.getTotalElements(),
+            page.getTotalPages(),
+            page.hasNext()
+        );
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatFileService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatFileService.java
@@ -1,0 +1,58 @@
+package com.example.communicationservice.service;
+
+import com.example.communicationservice.client.S3ServiceClient;
+import com.example.communicationservice.client.dto.input.FileUploadUrlGenerateInput;
+import com.example.communicationservice.client.dto.output.FileUploadUrlGenerateOutput;
+import com.example.communicationservice.common.exception.ChatRoomException;
+import com.example.communicationservice.common.status.ResponseDtoStatus;
+import com.example.communicationservice.controller.dto.request.ChatFileUploadUrlGenerateRequest;
+import com.example.communicationservice.controller.dto.response.ChatFileUploadUrlGenerateResponse;
+import com.example.communicationservice.entity.ChatRoom;
+import com.example.communicationservice.mapper.ChatMapper;
+import com.example.communicationservice.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.hexagon.core.vo.ServiceName;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatFileService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final S3ServiceClient s3ServiceClient;
+
+    /**
+     * 채팅방에 파일을 업로드하는 데 필요한 pre-signed upload URL을 생성합니다.
+     * @param roomId 파일을 업로드할 채팅방 아이디
+     * @param senderCode 파일을 업로드할 회원의 코드
+     * @param request pre-signed upload URL 생성 요청
+     * @return pre-signed upload URL 생성 응답
+     */
+    public ChatFileUploadUrlGenerateResponse generateUploadUrl(
+        String roomId,
+        String senderCode,
+        ChatFileUploadUrlGenerateRequest request
+    ) {
+        // 해당 채팅방이 존재하는지 확인
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+            .orElseThrow(() -> new ChatRoomException(ResponseDtoStatus.CHATROOM_NOT_FOUND));
+
+        // 파일을 업로드하려는 회원이 해당 채팅방의 참여자인지 확인
+        if (!chatRoom.getMemberCodes().contains(senderCode)) {
+            throw new ChatRoomException(ResponseDtoStatus.CHATROOM_FORBIDDEN);
+        }
+
+        // feign client 요청 dto 생성
+        FileUploadUrlGenerateInput input = new FileUploadUrlGenerateInput(
+            ServiceName.CHATS,
+            request.fileName(),
+            request.contentType()
+        );
+
+        // S3 service에 pre-signed upload URL 발급 요청
+        FileUploadUrlGenerateOutput output = s3ServiceClient.generateUploadUrl(input).data();
+
+        return ChatMapper.from(output);
+    }
+
+}

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatFileService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatFileService.java
@@ -8,7 +8,7 @@ import com.example.communicationservice.common.status.ResponseDtoStatus;
 import com.example.communicationservice.controller.dto.request.ChatFileUploadUrlGenerateRequest;
 import com.example.communicationservice.controller.dto.response.ChatFileUploadUrlGenerateResponse;
 import com.example.communicationservice.entity.ChatRoom;
-import com.example.communicationservice.mapper.ChatMapper;
+import com.example.communicationservice.mapper.FileMapper;
 import com.example.communicationservice.repository.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.hexagon.core.vo.ServiceName;
@@ -52,7 +52,7 @@ public class ChatFileService {
         // S3 service에 pre-signed upload URL 발급 요청
         FileUploadUrlGenerateOutput output = s3ServiceClient.generateUploadUrl(input).data();
 
-        return ChatMapper.from(output);
+        return FileMapper.from(output);
     }
 
 }

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
@@ -13,6 +13,7 @@ import com.example.communicationservice.controller.dto.response.PageInfo;
 import com.example.communicationservice.entity.ChatMessage;
 import com.example.communicationservice.entity.ChatRoom;
 import com.example.communicationservice.mapper.ChatMapper;
+import com.example.communicationservice.mapper.PageMapper;
 import com.example.communicationservice.repository.ChatMessageRepository;
 import com.example.communicationservice.repository.ChatRoomRepository;
 import com.example.communicationservice.type.MessageType;
@@ -57,7 +58,7 @@ public class ChatMessageService {
             .toList();
 
         // Page 정보 추출 및 DTO 생성
-        PageInfo pageInfo = ChatMapper.toPageInfo(messagePage);
+        PageInfo pageInfo = PageMapper.toPageInfo(messagePage);
 
         return new ChatMessageListReadResponse(messages, pageInfo);
     }

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
@@ -1,5 +1,8 @@
 package com.example.communicationservice.service;
 
+import com.example.communicationservice.client.S3ServiceClient;
+import com.example.communicationservice.client.dto.input.FileDownloadUrlGenerateInput;
+import com.example.communicationservice.client.dto.output.FileDownloadUrlListGenerateOutput;
 import com.example.communicationservice.common.exception.ChatRoomException;
 import com.example.communicationservice.common.status.ResponseDtoStatus;
 import com.example.communicationservice.controller.dto.request.ChatMessageSendRequest;
@@ -12,11 +15,11 @@ import com.example.communicationservice.entity.ChatRoom;
 import com.example.communicationservice.mapper.ChatMapper;
 import com.example.communicationservice.repository.ChatMessageRepository;
 import com.example.communicationservice.repository.ChatRoomRepository;
+import com.example.communicationservice.type.MessageType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.util.List;
@@ -27,6 +30,7 @@ public class ChatMessageService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final S3ServiceClient s3ServiceClient;
 
     /**
      * 특정 채팅방의 메시지 목록을 페이징하여 조회합니다.
@@ -59,12 +63,14 @@ public class ChatMessageService {
     }
 
     /**
-     * 특정 채팅방의 메시지를 저장합니다.
-     * @param request 저장할 채팅 메시지 전송 요청
+     * 채팅 메시지 전송을 처리합니다. <br>
+     * - 채팅 메시지를 DB에 저장하고 <br>
+     * - 파일이 포함된 경우 pre-signed download URL을 생성한 뒤 <br>
+     * - 브로드캐스트할 응답 형태로 변환합니다. <br>
+     * @param request 채팅 메시지 전송 요청
      * @return 수신할 메시지
      */
-    @Transactional
-    public ChatMessageSendResponse saveMessage(ChatMessageSendRequest request) {
+    public ChatMessageSendResponse sendMessage(ChatMessageSendRequest request) {
         // 해당 채팅방이 존재하는지 확인
         ChatRoom chatRoom = chatRoomRepository.findById(request.roomId())
             .orElseThrow(() -> new ChatRoomException(ResponseDtoStatus.CHATROOM_NOT_FOUND));
@@ -83,7 +89,29 @@ public class ChatMessageService {
         chatRoom.setUpdatedAt(Instant.now());
         chatRoomRepository.save(chatRoom);
 
-        return ChatMapper.toSendResponse(savedChatMessage);
+        // pre-signed download URL 생성
+        FileDownloadUrlListGenerateOutput output = generateDownloadUrl(request);
+
+        return ChatMapper.toSendResponse(savedChatMessage, output);
+    }
+
+    /**
+     * s3 service와 통신해 pre-signed download URL을 생성합니다.
+     * @param request 저장할 채팅 메시지 전송 요청
+     * @return pre-signed download URL 생성 응답
+     */
+    private FileDownloadUrlListGenerateOutput generateDownloadUrl(ChatMessageSendRequest request) {
+        // 파일이 포함되지 않은 메시지인 경우 early return
+        if (MessageType.FILE != request.type() && MessageType.MIXED != request.type()) {
+            return null;
+        }
+
+        // feign client 요청 dto 생성
+        String key = request.file().key();
+        FileDownloadUrlGenerateInput input = new FileDownloadUrlGenerateInput(List.of(key));
+
+        // S3 service에 pre-signed download URL 발급 요청
+        return s3ServiceClient.generateDownloadUrl(input).data();
     }
 
 }

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
@@ -1,7 +1,7 @@
 package com.example.communicationservice.service;
 
 import com.example.communicationservice.client.MemberServiceClient;
-import com.example.communicationservice.client.dto.MemberExistOutput;
+import com.example.communicationservice.client.dto.output.MemberExistOutput;
 import com.example.communicationservice.common.exception.ChatRoomException;
 import com.example.communicationservice.common.status.ResponseDtoStatus;
 import com.example.communicationservice.controller.dto.request.ChatRoomCreateRequest;

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatRoomService.java
@@ -11,6 +11,7 @@ import com.example.communicationservice.controller.dto.response.ChatRoomReadResp
 import com.example.communicationservice.controller.dto.response.PageInfo;
 import com.example.communicationservice.entity.ChatRoom;
 import com.example.communicationservice.mapper.ChatMapper;
+import com.example.communicationservice.mapper.PageMapper;
 import com.example.communicationservice.repository.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -84,7 +85,7 @@ public class ChatRoomService {
             .toList();
 
         // Page 정보 추출 및 DTO 생성
-        PageInfo pageInfo = ChatMapper.toPageInfo(chatRoomPage);
+        PageInfo pageInfo = PageMapper.toPageInfo(chatRoomPage);
 
         return new ChatRoomListReadResponse(chatRooms, pageInfo);
     }

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatFileServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatFileServiceTest.java
@@ -1,0 +1,140 @@
+package com.example.communicationservice.service;
+
+import com.example.communicationservice.client.S3ServiceClient;
+import com.example.communicationservice.client.dto.input.FileUploadUrlGenerateInput;
+import com.example.communicationservice.client.dto.output.FileUploadUrlGenerateOutput;
+import com.example.communicationservice.common.exception.ChatRoomException;
+import com.example.communicationservice.common.status.ResponseDtoStatus;
+import com.example.communicationservice.controller.dto.request.ChatFileUploadUrlGenerateRequest;
+import com.example.communicationservice.controller.dto.response.ChatFileUploadUrlGenerateResponse;
+import com.example.communicationservice.entity.ChatRoom;
+import com.example.communicationservice.mapper.ChatMapper;
+import com.example.communicationservice.repository.ChatRoomRepository;
+import org.hexagon.core.dto.ResponseDto;
+import org.hexagon.core.vo.ServiceName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ChatFileServiceTest {
+
+    @InjectMocks
+    private ChatFileService chatFileService;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private S3ServiceClient s3ServiceClient;
+
+    @Nested
+    class ChatFileUploadUrlGenerateTest {
+        private static final String ROOM_ID = "room-1";
+        private static final String ROOM_NAME = "test-room";
+        private static final String SENDER_CODE = "user-1";
+        private static final String FILE_NAME = "test.png";
+        private static final String CONTENT_TYPE = "image/png";
+
+        // 파일 업로드 URL 생성 요청 dto
+        private final ChatFileUploadUrlGenerateRequest request =
+            new ChatFileUploadUrlGenerateRequest(FILE_NAME, CONTENT_TYPE);
+
+        @Test
+        void 정상적으로_파일_업로드_URL을_반환한다() {
+            // given
+            String receiverCode = "user-2";
+            String fileKey = "generated/key";
+            String queryString = "?query=string";
+            List<String> memberCodes = List.of(SENDER_CODE, receiverCode);
+
+            ChatRoom chatRoom = ChatRoom.builder()
+                .name(ROOM_NAME)
+                .memberCodes(memberCodes)
+                .build();
+
+            when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(chatRoom));
+
+            FileUploadUrlGenerateOutput output =
+                new FileUploadUrlGenerateOutput(fileKey, queryString);
+
+            when(s3ServiceClient.generateUploadUrl(any(FileUploadUrlGenerateInput.class)))
+                .thenReturn(ResponseDto.success(output));
+
+            ChatFileUploadUrlGenerateResponse expectedResponse =
+                new ChatFileUploadUrlGenerateResponse(
+                    fileKey,
+                    queryString
+                );
+
+            // when + then
+            // try 안에서만 static mocking 유지
+            try (MockedStatic<ChatMapper> mockedStatic = mockStatic(ChatMapper.class)) {
+                mockedStatic.when(() -> ChatMapper.of(output))
+                    .thenReturn(expectedResponse);
+
+                // when
+                ChatFileUploadUrlGenerateResponse actualResponse =
+                    chatFileService.generateUploadUrl(ROOM_ID, SENDER_CODE, request);
+
+                // then
+                assertEquals(expectedResponse, actualResponse);
+
+                ArgumentCaptor<FileUploadUrlGenerateInput> captor =
+                    ArgumentCaptor.forClass(FileUploadUrlGenerateInput.class);
+
+                verify(s3ServiceClient, times(1)).generateUploadUrl(captor.capture());
+                assertEquals(ServiceName.CHATS, captor.getValue().serviceName());
+            }
+        }
+
+        @Test
+        void 채팅방_아이디에_해당되는_채팅방이_존재하지_않으면_CHATROOM_NOT_FOUND_예외가_발생한다() {
+            // given
+            when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.empty());
+
+            // when & then
+            ChatRoomException ex = assertThrows(
+                ChatRoomException.class,
+                () -> chatFileService.generateUploadUrl(ROOM_ID, SENDER_CODE, request)
+            );
+
+            assertEquals(ResponseDtoStatus.CHATROOM_NOT_FOUND, ex.getStatus());
+        }
+
+        @Test
+        void URL_생성_요청자가_채팅방의_참여자가_아니면_CHATROOM_FORBIDDEN_예외가_발생한다() {
+            // given
+            List<String> memberCodes = List.of("other-user-1", "other-user-2"); // 요청자 코드 없음
+
+            ChatRoom chatRoom = ChatRoom.builder()
+                .name(ROOM_NAME)
+                .memberCodes(memberCodes)
+                .build();
+
+            when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(chatRoom));
+
+            // when & then
+            ChatRoomException ex = assertThrows(
+                ChatRoomException.class,
+                () -> chatFileService.generateUploadUrl(ROOM_ID, SENDER_CODE, request)
+            );
+
+            assertEquals(ResponseDtoStatus.CHATROOM_FORBIDDEN, ex.getStatus());
+        }
+    }
+
+}

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatFileServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatFileServiceTest.java
@@ -83,7 +83,7 @@ public class ChatFileServiceTest {
             // when + then
             // try 안에서만 static mocking 유지
             try (MockedStatic<ChatMapper> mockedStatic = mockStatic(ChatMapper.class)) {
-                mockedStatic.when(() -> ChatMapper.of(output))
+                mockedStatic.when(() -> ChatMapper.from(output))
                     .thenReturn(expectedResponse);
 
                 // when

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatFileServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatFileServiceTest.java
@@ -8,7 +8,7 @@ import com.example.communicationservice.common.status.ResponseDtoStatus;
 import com.example.communicationservice.controller.dto.request.ChatFileUploadUrlGenerateRequest;
 import com.example.communicationservice.controller.dto.response.ChatFileUploadUrlGenerateResponse;
 import com.example.communicationservice.entity.ChatRoom;
-import com.example.communicationservice.mapper.ChatMapper;
+import com.example.communicationservice.mapper.FileMapper;
 import com.example.communicationservice.repository.ChatRoomRepository;
 import org.hexagon.core.dto.ResponseDto;
 import org.hexagon.core.vo.ServiceName;
@@ -82,8 +82,8 @@ public class ChatFileServiceTest {
 
             // when + then
             // try 안에서만 static mocking 유지
-            try (MockedStatic<ChatMapper> mockedStatic = mockStatic(ChatMapper.class)) {
-                mockedStatic.when(() -> ChatMapper.from(output))
+            try (MockedStatic<FileMapper> mockedStatic = mockStatic(FileMapper.class)) {
+                mockedStatic.when(() -> FileMapper.from(output))
                     .thenReturn(expectedResponse);
 
                 // when

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
@@ -152,7 +152,7 @@ class ChatMessageServiceTest {
             .willReturn(savedMessage);
 
         // when
-        ChatMessageSendResponse response = chatMessageService.saveMessage(request);
+        ChatMessageSendResponse response = chatMessageService.sendMessage(request);
 
         // then
         assertThat(response).isNotNull();
@@ -180,7 +180,7 @@ class ChatMessageServiceTest {
 
         // when & then
         ChatRoomException exception = assertThrows(ChatRoomException.class,
-            () -> chatMessageService.saveMessage(request));
+            () -> chatMessageService.sendMessage(request));
 
         assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_NOT_FOUND);
 
@@ -206,7 +206,7 @@ class ChatMessageServiceTest {
 
         // when & then
         ChatRoomException exception = assertThrows(ChatRoomException.class,
-            () -> chatMessageService.saveMessage(request));
+            () -> chatMessageService.sendMessage(request));
 
         assertThat(exception.getStatus()).isEqualTo(ResponseDtoStatus.CHATROOM_FORBIDDEN);
 

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatRoomServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatRoomServiceTest.java
@@ -1,7 +1,7 @@
 package com.example.communicationservice.service;
 
 import com.example.communicationservice.client.MemberServiceClient;
-import com.example.communicationservice.client.dto.MemberExistOutput;
+import com.example.communicationservice.client.dto.output.MemberExistOutput;
 import com.example.communicationservice.common.exception.ChatRoomException;
 import com.example.communicationservice.common.status.ResponseDtoStatus;
 import com.example.communicationservice.controller.dto.request.ChatRoomCreateRequest;


### PR DESCRIPTION
## 🐛 관련 이슈
 <!-- Closes #{이슈-번호} 형태로 작성하세요 (ex: Closes #134) -->
Closes #175 

## 📌 목적
채팅방에서 파일 메시지를 전송하는 기능을 구현합니다.

## ✅ 변경 사항
### 🪜 개요
메시지 송신자 관점에서 `파일 메시지를 전송`하는 기능은 크게 두 단계로 나뉩니다.

1. `pre-signed upload URL을 발급`받은 뒤 전송하려는 파일을 `AWS S3에 업로드`합니다.

2. websocket(STOMP)을 통해 `파일이 포함된 메시지를 전송`합니다.

<br>

기술적으로 복잡한 구현이 있다기보다는, 클라이언트부터 Communication Service, S3 Service, AWS S3를 아우르는 전체 흐름을 이해하는 것이 핵심이라고 생각합니다.

시퀀스 다이어그램과 하단의 설명을 참고해주시면 감사하겠습니다.

<br>

### 1️⃣ [pre-signed upload URL 발급 및 파일 업로드](https://github.com/prgrms-be-adv-devcourse/beadv1_1_hexagon_BE/commit/94600cd788bedc15324af10b02b90f646dd44a27)

```mermaid
sequenceDiagram
    participant AWS S3
    participant Client(Sender)
    participant Communication Service
    participant S3 Service

    Note over Client(Sender), Communication Service: [1] 파일 업로드 URL 요청
    Client(Sender)->>Communication Service: POST /api/chatrooms/{room-id}/files/upload-url<br>request body: {fileName, contentType}
    Communication Service->>Communication Service: 유효성 검증
  
    Note over Communication Service, S3 Service: [2] 파일 업로드 URL 생성
    Communication Service->>S3 Service: POST /internal/s3/upload-url<br>request body: {serviceName, fileName, contentType}
    S3 Service->>S3 Service: 파일 업로드 URL 생성
    S3 Service-->>Communication Service: 파일 업로드 URL 응답<br> response body: {key, queryString}
    Communication Service-->>Client(Sender): 파일 업로드 URL 응답<br> response body: {key, queryString}    
    Note over Client(Sender), AWS S3: [3] S3에 파일 업로드
    Client(Sender)->>Client(Sender): 파일 업로드 URL 조합<br>(bucket/region + key + queryString)
    Client(Sender)->>AWS S3: URL로 파일 업로드
```

1. 메시지 송신자 측 클라이언트는 Communication Service에 `파일 업로드 URL 생성을 요청`합니다. 

    - 파일 업로드 URL 생성을 S3 Service에 직접 요청하지 않습니다.
    
    - 파일 업로드 권한을 Communication Service에서 검증하여 해당 채팅방의 참여자가 아닌 사용자가 임의로 파일을 업로드하는 것을 방지하기 위함입니다.

2. Communication Service는 feign client를 이용해 S3 Service에 `파일 업로드 URL 생성을 요청`합니다.

4. 메시지 송신자 측 클라이언트는 Communication Service에게 응답받은 key와 queryString을 조합해 AWS S3에 `파일을 업로드`합니다.

    - `.env` 파일에 저장된 bucket/region 정보와 key, queryString을 조합합니다.
    
    - 최종적으로 https://`{bucket}`.s3.`{region}`.amazonaws.com/`{key}` `{queryString}`과 같은 형태가 됩니다.

<br>

### 2️⃣ [파일이 포함된 메시지 전송](https://github.com/prgrms-be-adv-devcourse/beadv1_1_hexagon_BE/commit/434b6f9cdcb0dd18f3d7a6f744b281c041f3bf8b)

```mermaid
sequenceDiagram
    participant Client(Receiver)
    participant Client(Sender)
    participant Communication Service
    participant S3 Service
    participant AWS S3

    Note over Client(Sender), Communication Service: [1] 채팅 메시지 전송
    Client(Sender)->>Communication Service: websocket /app/chat.send<br> payload: {roomId, senderCode, type, text, file}
    Communication Service->>Communication Service: 유효성 검증
    Communication Service->>Communication Service: DB에 채팅 메시지 저장
    
    alt 파일이 포함된 메시지인 경우
        Note over Communication Service, S3 Service: [2] 파일 다운로드 URL 생성
        Communication Service->>S3 Service: POST /internal/s3/download-url/key<br>request body: {keys}
        S3 Service->>S3 Service: 파일 다운로드 URL 생성
        S3 Service-->>Communication Service: 파일 다운로드 URL 응답<br> response body: {urls}
    end
	  
	  Note over Client(Receiver), Communication Service: [3] 웹소켓 브로드캐스트
		Communication Service->>Client(Sender): 파일 다운로드 URL 포함 메시지 전달<br> payload: {messageId, roomId, senderCode, type, text, file, sentAt}
		Communication Service->>Client(Receiver): 파일 다운로드 URL 포함 메시지 전달<br> payload: {messageId, roomId, senderCode, type, text, file, sentAt}
		
		Note over Client(Receiver), AWS S3: [4] S3에서 파일 다운로드
		Client(Sender)->>Client(Sender): 파일 다운로드 URL 조합<br>(bucket/region + key + queryString)
		Client(Sender)->>AWS S3: URL로 파일 다운로드
		Client(Receiver)->>Client(Receiver): 파일 다운로드 URL 조합<br>(bucket/region + key + queryString)
		Client(Receiver)->>AWS S3: URL로 파일 다운로드
```

1. 메시지 송신자 측 클라이언트는 websocket(STOMP)을 통해 `메시지를 전송`합니다.

    - 클라이언트는 파일 업로드에 사용한 key를 반드시 메시지 페이로드에 포함해야 합니다.
    
    - Communication Service는 메시지 처리 과정에서 유효성 검증을 수행하고, 채팅 메시지를 DB에 저장합니다.

2. 메시지에 파일이 포함된 경우, 즉 메시지 타입이 `MessageType.FILE` 또는 `MessageType.MIXED`인 경우에는 feign client를 이용해 S3 Service에 `파일 다운로드 URL 생성을 요청`합니다.

    - 이 시점에 파일 다운로드 URL을 발급받는 이유는, 메시지를 수신하는 채팅방 참여자들이 추가 요청 없이 즉시 파일을 다운로드할 수 있도록 하기 위함입니다.

3. Communication Service는 메시지 브로커 역할을 수행하여 `메시지를 적절한 대상(채팅방 참여자)에게 전달`합니다. 

    - S3 Service에게 응답받은 key와 queryString을 포함하여 브로드캐스트할 메시지 페이로드를 구성합니다.

4. 채팅방 참여자 측 클라이언트는 Communication Service에게 응답받은 key와 queryString을 조합해 AWS S3에서 `파일을 다운로드`합니다.

    - 조합 방법은 1️⃣ pre-signed upload URL 발급 및 파일 업로드 단계의 3번과 동일합니다.

## 🧪 테스트 방법

- 기존 서비스 단위 테스트 코드에 변경 사항을 반영했습니다.

- 신규 서비스 단위 테스트 코드를 작성했습니다.

## 📎 참고 사항
### 1️⃣ 파일 존재 여부 확인 생략

- 파일 메시지 전송 시, 해당 파일이 실제로 AWS S3에 존재하는지 확인하는 API(GET /internal/s3/exists)는 사용하지 않았습니다. 

- pre-signed URL 방식 특성상 파일 업로드는 서버를 거치지 않고 클라이언트와 S3 간에 직접 이루어집니다. 따라서 메시지 전송 시점에 서버가 업로드 완료 여부를 동기적으로 보장하기 어렵다고 판단했습니다.

```
[1] 서버 → pre-signed upload URL 발급
[2] 클라이언트 → websocket 메시지 전송
[3] 서버 → S3에 파일 존재 여부 확인 → 존재하지 않음 ❌
[4] 클라이언트 → S3 업로드 성공 ⭕
```

- 실시간성이 중요한 채팅 서비스 특성상, 메시지 전송 흐름에 파일 존재 여부 확인을 추가할 경우 불필요한 네트워크 호출로 인한 레이턴시 증가가 발생할 수 있어 현재 구현에서는 낙관적으로 처리했습니다.

### 2️⃣ 미참조 파일 발생 가능성

- 파일은 업로드는 성공했지만 메시지는 전송하지 않는 경우, 어디에서도 참조되지 않는 파일 객체가 AWS S3에 남아 있을 수 있습니다. 

- 다른 모듈과 동일하게 파일 업로드 시 임시 파일 상태로 관리하고, 메시지 저장이 성공한 시점에만 확정 처리하는 방식을 고려할 수 있다고 생각합니다.

```
[1] 서버 → pre-signed upload URL 발급 (key = temp/...)
[2] 클라이언트 → S3 업로드
[3] 클라이언트 → websocket 메시지 전송
[4] 서버 → 메시지 저장 성공 → 파일 확정 처리
[5] S3 Lifecycle → `temp/*` 자동 정리
```

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [x] 이슈 번호를 입력 했나요?
- [x] 코드 컨벤션을 모두 지켰나요?
- [x] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
