### PR TITLE
feat(member): 멤버 모듈 S3 이미지 관련 로직 추가

### DIFF
--- a/gateway-service/src/main/java/com/example/gatewayservice/common/exception/ErrorCode.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/common/exception/ErrorCode.java
@@ -10,8 +10,8 @@ public enum ErrorCode {
     NEED_RE_LOGIN(401, 2501, "로그인을 다시 해주세요."),
     NEED_RE_ISSUE(401, 2502, "AccessToken을 재발행해주세요."),
     NEED_SIGNUP(403, 2503, "회원가입이 필요합니다."),
-    FORBIDDEN_CLIENT(403, 2504, "CLIENT 권한이 필요한 요청입니다. 권한 등록 이후 시도해주세요."),
-    FORBIDDEN_FREELANCER(403, 2505, "FREELANCER 권한이 필요한 요청입니다. 권한 등록 이후 시도해주세요.");
+    REQUIRED_CLIENT_ROLE(403, 2504, "CLIENT 권한이 필요한 요청입니다. 권한 등록 이후 시도해주세요."),
+    REQUIRED_FREELANCER_ROLE(403, 2505, "FREELANCER 권한이 필요한 요청입니다. 권한 등록 이후 시도해주세요.");
 
 
     private final int statusCode;

--- a/gateway-service/src/main/java/com/example/gatewayservice/common/jwt/JwtTokenValidator.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/common/jwt/JwtTokenValidator.java
@@ -3,6 +3,7 @@ package com.example.gatewayservice.common.jwt;
 import com.example.gatewayservice.common.exception.BusinessException;
 import com.example.gatewayservice.common.exception.ErrorCode;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,11 @@ public class JwtTokenValidator {
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();
-        } catch (JwtException e) {
+        }catch(ExpiredJwtException e){
+            log.info("accessToken이 만료되었습니다.");
+            throw new BusinessException(ErrorCode.NEED_RE_ISSUE);
+        }
+        catch (JwtException e) {
             log.info("acesssToken 검증이 실패했습니다.");
             throw new BusinessException(ErrorCode.UNAUTHORIZATION);
         }

--- a/gateway-service/src/main/java/com/example/gatewayservice/filter/GlobalExceptionHandlingFilter.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/filter/GlobalExceptionHandlingFilter.java
@@ -7,6 +7,7 @@ import com.example.gatewayservice.common.web.model.dto.ResponseDto;
 import com.example.gatewayservice.common.web.model.vo.Empty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.http.HttpStatus;
@@ -18,6 +19,7 @@ import reactor.core.publisher.Mono;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
+@Slf4j
 @Component
 public class GlobalExceptionHandlingFilter
     extends AbstractGatewayFilterFactory<GlobalExceptionHandlingFilter.Config> {
@@ -38,6 +40,7 @@ public class GlobalExceptionHandlingFilter
         return (exchange, chain) -> chain.filter(exchange)
             .onErrorResume(BusinessException.class, ex -> {
                 ErrorCode errorCode = ex.getErrorCode();
+                log.info("gateway 단에서 문제가 생겼습니다.");
                 return writeErrorResponse(exchange.getResponse(), errorCode);
             });
     }

--- a/gateway-service/src/main/java/com/example/gatewayservice/filter/IsClientCheckFilter.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/filter/IsClientCheckFilter.java
@@ -45,7 +45,7 @@ public class IsClientCheckFilter extends
 
             if (!ALLOWED_ROLES.contains(role.toUpperCase())) {
                 log.info("CLIENT 권한이 없음. role={}", role);
-                throw new BusinessException(ErrorCode.FORBIDDEN_CLIENT);
+                throw new BusinessException(ErrorCode.REQUIRED_CLIENT_ROLE);
             }
 
             return chain.filter(exchange);

--- a/gateway-service/src/main/java/com/example/gatewayservice/filter/IsFreelancerCheckFilter.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/filter/IsFreelancerCheckFilter.java
@@ -44,7 +44,7 @@ public class IsFreelancerCheckFilter extends AbstractGatewayFilterFactory<Config
 
             if (!ALLOWED_ROLES.contains(role.toUpperCase())) {
                 log.info("FREELANCER 권한이 없음. role={}", role);
-                throw new BusinessException(ErrorCode.FORBIDDEN_FREELANCER);
+                throw new BusinessException(ErrorCode.REQUIRED_FREELANCER_ROLE);
             }
 
             return chain.filter(exchange);

--- a/member-service/src/main/java/com/example/memberservice/auth/email/controller/EmailAuthApiController.java
+++ b/member-service/src/main/java/com/example/memberservice/auth/email/controller/EmailAuthApiController.java
@@ -39,10 +39,6 @@ public class EmailAuthApiController implements EmailAuthApiControllerSwagger {
         @RequestHeader(name = "X-CODE") String memberCode,
         @RequestBody @Valid CreateEmailAuthRequest request) {
 
-        log.info("memberCode: {}, role: {}, email: {}", memberCode, role, request.email());
-        long start = System.currentTimeMillis();
-        log.info("START_TIME_MS: {}", start);
-
         roleCheck(role);
 
         emailAuthService.sendAuthMail(CreateEmailAuthInput.builder()
@@ -52,8 +48,6 @@ public class EmailAuthApiController implements EmailAuthApiControllerSwagger {
             .build()
         );
 
-        long elapsed = System.currentTimeMillis() - start;
-        log.info("ELAPSED: {} ms", elapsed);
         return ResponseDto.success();
     }
 

--- a/member-service/src/main/java/com/example/memberservice/auth/token/service/AuthService.java
+++ b/member-service/src/main/java/com/example/memberservice/auth/token/service/AuthService.java
@@ -38,14 +38,13 @@ public class AuthService {
         refreshTokenRepository.saveRefreshToken(memberCode, newRefreshToken);
 
         Optional<Members> optionalMembers = memberJpaRepository.findByCode(memberCode);
-        
 
-        Members members = optionalMembers.orElse(null);
-        String newAccessToken = (members != null)
-            //회원 가입 한 사용자의 경우 memberRole을 claims 에 추가
-            ? jwtTokenGenerator.generateAccessToken(members.getCode(), true, members.getRole())
-            //회원 가입 안한 사용자의 경우 memberRole을 claims 에 추가 안함.
-            : jwtTokenGenerator.generateAccessToken(memberCode, false);
+
+        String newAccessToken = optionalMembers
+            .map(members -> // Optional 안에 값이 존재할 때 실행할 로직
+                jwtTokenGenerator.generateAccessToken(members.getCode(), true, members.getRole()))
+            .orElseGet(() -> // Optional 안에 값이 존재하지 않을 때 실행할 로직
+                jwtTokenGenerator.generateAccessToken(memberCode, false));
 
         return new TokensOutput(newAccessToken, newRefreshToken);
     }

--- a/member-service/src/main/java/com/example/memberservice/common/client/ContractServiceClient.java
+++ b/member-service/src/main/java/com/example/memberservice/common/client/ContractServiceClient.java
@@ -1,7 +1,7 @@
 package com.example.memberservice.common.client;
 
 
-import com.example.memberservice.common.client.dto.response.ContractStateResponse;
+import com.example.memberservice.common.client.dto.response.contract.ContractStateResponse;
 import org.hexagon.core.dto.ResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/member-service/src/main/java/com/example/memberservice/common/client/RatingServiceClient.java
+++ b/member-service/src/main/java/com/example/memberservice/common/client/RatingServiceClient.java
@@ -1,0 +1,19 @@
+package com.example.memberservice.common.client;
+
+import com.example.memberservice.common.client.dto.response.rating.RatingResponse;
+import org.hexagon.core.dto.ResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(
+    name = "profile-service",
+    contextId = "profileRatingService",
+    path = "/api/ratings"
+)
+public interface RatingServiceClient {
+    @GetMapping("/{memberCode}")
+    ResponseDto<RatingResponse> getMemberRating(
+        @PathVariable("memberCode") String memberCode
+    );
+}

--- a/member-service/src/main/java/com/example/memberservice/common/client/S3ServiceClient.java
+++ b/member-service/src/main/java/com/example/memberservice/common/client/S3ServiceClient.java
@@ -1,0 +1,43 @@
+package com.example.memberservice.common.client;
+
+
+import com.example.memberservice.common.client.dto.request.s3.PresignedDownloadRequestByCode;
+import com.example.memberservice.common.client.dto.request.s3.StoreKeysRequest;
+import com.example.memberservice.common.client.dto.response.s3.PresignedDownloadListResponse;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import org.hexagon.core.dto.Empty;
+import org.hexagon.core.dto.ResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(
+    name = "s3-service",
+    path = "/internal/s3"
+)
+public interface S3ServiceClient {
+
+    /**
+     * code 기준 다운로드 URL 조회
+     */
+    @PostMapping("/download-url/code")
+    ResponseDto<PresignedDownloadListResponse> getDownloadUrlByCode(
+        @RequestBody PresignedDownloadRequestByCode request
+    );
+
+    /**
+     * S3 리소스 저장
+     */
+    @PostMapping("/s3-resource")
+    ResponseDto<Empty> storeKeys(
+        @RequestBody StoreKeysRequest request
+    );
+
+    /**
+     * S3 리소스 동기화
+     */
+    @PatchMapping("/s3-resource")
+    ResponseDto<Empty> updateKeys(
+        @RequestBody StoreKeysRequest request
+    );
+}

--- a/member-service/src/main/java/com/example/memberservice/common/client/TagServiceClient.java
+++ b/member-service/src/main/java/com/example/memberservice/common/client/TagServiceClient.java
@@ -1,0 +1,21 @@
+package com.example.memberservice.common.client;
+
+
+import com.example.memberservice.common.client.dto.response.tag.TagResponse;
+import java.util.List;
+import org.hexagon.core.dto.ResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(
+    name = "profile-service",
+    contextId = "profileTagService",
+    path = "/api/tags"
+)
+public interface TagServiceClient {
+    @GetMapping("/me")
+    ResponseDto<List<TagResponse>> getMyTags(
+        @RequestHeader("X-CODE") String memberCode
+    );
+}

--- a/member-service/src/main/java/com/example/memberservice/common/client/dto/request/s3/PresignedDownloadRequestByCode.java
+++ b/member-service/src/main/java/com/example/memberservice/common/client/dto/request/s3/PresignedDownloadRequestByCode.java
@@ -1,0 +1,7 @@
+package com.example.memberservice.common.client.dto.request.s3;
+
+public record PresignedDownloadRequestByCode(
+        String code
+) {
+
+}

--- a/member-service/src/main/java/com/example/memberservice/common/client/dto/request/s3/PresignedDownloadRequestByKey.java
+++ b/member-service/src/main/java/com/example/memberservice/common/client/dto/request/s3/PresignedDownloadRequestByKey.java
@@ -1,0 +1,9 @@
+package com.example.memberservice.common.client.dto.request.s3;
+
+import java.util.List;
+
+public record PresignedDownloadRequestByKey(
+        List<String> keys
+) {
+
+}

--- a/member-service/src/main/java/com/example/memberservice/common/client/dto/request/s3/StoreKeysRequest.java
+++ b/member-service/src/main/java/com/example/memberservice/common/client/dto/request/s3/StoreKeysRequest.java
@@ -1,0 +1,10 @@
+package com.example.memberservice.common.client.dto.request.s3;
+
+import java.util.List;
+
+public record StoreKeysRequest(
+        String code,
+        List<String> keys
+) {
+
+}

--- a/member-service/src/main/java/com/example/memberservice/common/client/dto/response/contract/ContractStateResponse.java
+++ b/member-service/src/main/java/com/example/memberservice/common/client/dto/response/contract/ContractStateResponse.java
@@ -1,4 +1,4 @@
-package com.example.memberservice.common.client.dto.response;
+package com.example.memberservice.common.client.dto.response.contract;
 
 public record ContractStateResponse(
     boolean isClient,

--- a/member-service/src/main/java/com/example/memberservice/common/client/dto/response/rating/RatingResponse.java
+++ b/member-service/src/main/java/com/example/memberservice/common/client/dto/response/rating/RatingResponse.java
@@ -1,0 +1,16 @@
+package com.example.memberservice.common.client.dto.response.rating;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RatingResponse(
+        @Schema(description = "평가를 받은 회원의 코드", example = "sa546a6-asd7f-sd57fs-sd5f7ds567ds5d")
+        String memberCode,
+
+        @Schema(description = "받은 만족 평가 개수", example = "42")
+        int satisfiedCount,
+
+        @Schema(description = "받은 불만족 평가 개수", example = "3")
+        int unsatisfiedCount
+) {
+
+}

--- a/member-service/src/main/java/com/example/memberservice/common/client/dto/response/s3/PresignedDownloadListResponse.java
+++ b/member-service/src/main/java/com/example/memberservice/common/client/dto/response/s3/PresignedDownloadListResponse.java
@@ -1,0 +1,9 @@
+package com.example.memberservice.common.client.dto.response.s3;
+
+import java.util.List;
+
+public record PresignedDownloadListResponse(
+        List<PresignedDownloadResponse> urls
+) {
+
+}

--- a/member-service/src/main/java/com/example/memberservice/common/client/dto/response/s3/PresignedDownloadResponse.java
+++ b/member-service/src/main/java/com/example/memberservice/common/client/dto/response/s3/PresignedDownloadResponse.java
@@ -1,0 +1,11 @@
+package com.example.memberservice.common.client.dto.response.s3;
+
+import org.hexagon.core.vo.FileType;
+
+public record PresignedDownloadResponse(
+        String key,
+        String queryString,
+        FileType fileType
+) {
+
+}

--- a/member-service/src/main/java/com/example/memberservice/common/client/dto/response/s3/PresignedUploadResponse.java
+++ b/member-service/src/main/java/com/example/memberservice/common/client/dto/response/s3/PresignedUploadResponse.java
@@ -1,0 +1,8 @@
+package com.example.memberservice.common.client.dto.response.s3;
+
+public record PresignedUploadResponse(
+        String key,
+        String queryString
+) {
+
+}

--- a/member-service/src/main/java/com/example/memberservice/common/client/dto/response/tag/TagResponse.java
+++ b/member-service/src/main/java/com/example/memberservice/common/client/dto/response/tag/TagResponse.java
@@ -1,0 +1,11 @@
+package com.example.memberservice.common.client.dto.response.tag;
+
+
+public record TagResponse(
+
+        String tagCode,
+
+        String skill
+) {
+
+}

--- a/member-service/src/main/java/com/example/memberservice/common/config/AsyncConfig.java
+++ b/member-service/src/main/java/com/example/memberservice/common/config/AsyncConfig.java
@@ -27,6 +27,25 @@ public class AsyncConfig implements AsyncConfigurer {
         return executor;
     }
 
+    @Bean(name = "externalApiExecutor")
+    public Executor externalApiExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(6);
+        executor.setMaxPoolSize(12);
+        executor.setQueueCapacity(50);
+
+        executor.setThreadNamePrefix("External-API-");
+
+        executor.setRejectedExecutionHandler(
+            new ThreadPoolExecutor.CallerRunsPolicy()
+        );
+
+        executor.initialize();
+        return executor;
+    }
+
+
     @Override
     public Executor getAsyncExecutor() {
         return asyncExecutor(); // Async에서 사용할 Executor 지정

--- a/member-service/src/main/java/com/example/memberservice/common/kafka/consumer/MemberKafkaHandler.java
+++ b/member-service/src/main/java/com/example/memberservice/common/kafka/consumer/MemberKafkaHandler.java
@@ -6,6 +6,7 @@ import com.example.memberservice.member.service.MemberService;
 import com.example.memberservice.member.service.model.dto.input.MemberUpdateInput;
 import com.example.memberservice.member.service.model.dto.input.MemberUpdateRoleStateInput;
 import lombok.RequiredArgsConstructor;
+import org.hexagon.core.events.selfpromotion.SelfPromotionCreatedEvent;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -16,17 +17,16 @@ public class MemberKafkaHandler {
 
     private final MemberService memberService;
 
-    //TODO(이후 profile 모듈 카프카 전송 메서드 생성시 해당 Event 객체 참조하도록 수정)
-//    @KafkaListener(
-//        topics = "${kafka.topic.profile.freelancer-role-update-topic}",
-//        groupId = "${spring.kafka.consumer.group-id}",
-//        containerFactory = "kafkaListenerContainerFactory"
-//    )
-//    public void handleFreelancerRoleUpdate(TempEventDto event) {
-//
-//        memberService.updateMember(
-//            MemberServiceInputMapper.toUpdateMemberRoleStateInput(event.memberCode, event);
-//        );
-//    }
+    @KafkaListener(
+        topics = "${kafka.topic.profile.update-freelancer-role-topic}",
+        groupId = "${spring.kafka.consumer.group-id}",
+        containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void handleFreelancerRoleUpdate(SelfPromotionCreatedEvent event) {
+
+        memberService.updateMemberRoleState(
+            MemberServiceInputMapper.toUpdateMemberRoleStateInput(event)
+        );
+    }
 
 }

--- a/member-service/src/main/java/com/example/memberservice/common/kafka/producer/MemberKafkaEventProducer.java
+++ b/member-service/src/main/java/com/example/memberservice/common/kafka/producer/MemberKafkaEventProducer.java
@@ -52,18 +52,21 @@ public class MemberKafkaEventProducer implements MemberEventProducer{
     }
 
     @Override
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public CompletableFuture<SendResult<String, Object>> sendDeletedEvent(
         MemberDeletedEvent event) {
         return kafkaTemplate.send(memberDeletedTopicName, event.memberCode(), event);
     }
 
     @Override
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public CompletableFuture<SendResult<String, Object>> sendDeletedClientRoleEvent(
         MemberDeletedClientRoleEvent event) {
         return kafkaTemplate.send(memberClientRoleDeletedTopicName, event.memberCode(), event);
     }
 
     @Override
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public CompletableFuture<SendResult<String, Object>> sendDeletedFreelancerRoleEvent(
         MemberDeletedFreelancerRoleEvent event) {
         return kafkaTemplate.send(memberFreelancerRoleDeletedTopicName, event.memberCode(), event);

--- a/member-service/src/main/java/com/example/memberservice/member/controller/MemberApiController.java
+++ b/member-service/src/main/java/com/example/memberservice/member/controller/MemberApiController.java
@@ -43,9 +43,18 @@ public class MemberApiController implements MemberApiControllerSwagger {
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     public ResponseDto<MemberGetResponse> getMemberByCode(
-        @RequestHeader(name = "X-CODE", required = false) String xCode,
-        @RequestParam(name = "member-code", required = false) String paramCode) {
-        return ResponseDto.success(memberService.getMemberByCode(MemberServiceInputMapper.toGetMemberInput(xCode, paramCode)));
+        @RequestParam(name = "member-code") String paramCode
+    ) {
+        return ResponseDto.success(
+            memberService.getMemberByCode(MemberServiceInputMapper.toGetMemberInput(paramCode)));
+    }
+
+    @GetMapping("/me")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseDto<MemberGetResponse> getMyMemberByCode(
+        @RequestHeader(name = "X-CODE") String xCode) {
+        return ResponseDto.success(
+            memberService.getMemberByCode(MemberServiceInputMapper.toGetMemberInput(xCode)));
     }
 
     @PostMapping
@@ -53,7 +62,8 @@ public class MemberApiController implements MemberApiControllerSwagger {
     public ResponseDto<Empty> createMember(@RequestHeader(name = "X-CODE") String memberCode,
         @RequestBody MemberCreateRequest request) {
 
-        memberService.createMember(MemberServiceInputMapper.toCreateMemberInput(memberCode, request));
+        memberService.createMember(
+            MemberServiceInputMapper.toCreateMemberInput(memberCode, request));
 
         return ResponseDto.success(HttpStatus.CREATED);
     }
@@ -63,7 +73,8 @@ public class MemberApiController implements MemberApiControllerSwagger {
     public ResponseDto<Empty> updateMember(@RequestHeader(name = "X-CODE") String memberCode,
         @RequestBody MemberUpdateRequest request) {
 
-        memberService.updateMember(MemberServiceInputMapper.toUpdateMemberInput(memberCode, request));
+        memberService.updateMember(
+            MemberServiceInputMapper.toUpdateMemberInput(memberCode, request));
         return ResponseDto.success();
     }
 
@@ -72,11 +83,12 @@ public class MemberApiController implements MemberApiControllerSwagger {
     public ResponseDto<Empty> updateMemberRoleState(@RequestHeader("X-CODE") String memberCode,
         @RequestBody MemberRoleUpdateRequest request) {
 
-        if(!request.role().equals(MemberRole.CLIENT)){
+        if (!request.role().equals(MemberRole.CLIENT)) {
             throw new BusinessException(ErrorCode.NOT_ALLOW_ROLE_UPDATE);
         }
 
-        memberService.updateMemberRoleState(MemberServiceInputMapper.toUpdateMemberRoleStateInput(memberCode, request));
+        memberService.updateMemberRoleState(
+            MemberServiceInputMapper.toUpdateMemberRoleStateInput(memberCode, request));
         return ResponseDto.success();
     }
 
@@ -85,7 +97,8 @@ public class MemberApiController implements MemberApiControllerSwagger {
     public ResponseDto<Empty> deleteMemberRoleState(@RequestHeader("X-CODE") String memberCode,
         @RequestBody MemberRoleUpdateRequest request) {
 
-        memberService.deleteMemberRoleState(MemberServiceInputMapper.toUpdateMemberRoleStateInput(memberCode, request));
+        memberService.deleteMemberRoleState(
+            MemberServiceInputMapper.toUpdateMemberRoleStateInput(memberCode, request));
 
         return ResponseDto.success();
     }
@@ -105,7 +118,8 @@ public class MemberApiController implements MemberApiControllerSwagger {
     public ResponseDto<Empty> existMemberByName(@RequestHeader("X-CODE") String memberCode,
         @RequestParam(name = "name") String name) {
 
-        memberService.existMemberByNickName(MemberServiceInputMapper.toExistMemberByNameInput(memberCode, name));
+        memberService.existMemberByNickName(
+            MemberServiceInputMapper.toExistMemberByNameInput(memberCode, name));
 
         return ResponseDto.success();
     }

--- a/member-service/src/main/java/com/example/memberservice/member/controller/dto/request/MemberCreateRequest.java
+++ b/member-service/src/main/java/com/example/memberservice/member/controller/dto/request/MemberCreateRequest.java
@@ -1,5 +1,6 @@
 package com.example.memberservice.member.controller.dto.request;
 
+import jakarta.annotation.Nullable;
 import java.time.LocalDate;
 import io.swagger.v3.oas.annotations.media.Schema;
 import com.example.memberservice.member.model.enums.Gender;
@@ -17,7 +18,11 @@ public record MemberCreateRequest(
     LocalDate birthDate,
 
     @Schema(description = "사용자 성별", example = "MAN OR FEMALE")
-    Gender gender
+    Gender gender,
+
+    @Schema(description = "사용자 프로필 Image S3 Key", example = "/member/temp/TestImage.jpg")
+    @Nullable
+    String profileImageKey
 ) {
 
 }

--- a/member-service/src/main/java/com/example/memberservice/member/controller/dto/request/MemberUpdateRequest.java
+++ b/member-service/src/main/java/com/example/memberservice/member/controller/dto/request/MemberUpdateRequest.java
@@ -2,6 +2,7 @@ package com.example.memberservice.member.controller.dto.request;
 
 import com.example.memberservice.member.model.enums.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import java.time.LocalDate;
 
 public record MemberUpdateRequest(
@@ -16,7 +17,11 @@ public record MemberUpdateRequest(
     LocalDate birthDate,
 
     @Schema(description = "사용자 성별", example = "MAN OR FEMALE")
-    Gender gender
+    Gender gender,
+
+    @Schema(description = "사용자 프로필 Image S3 Key", example = "/member/temp/TestImage.jpg")
+    @Nullable
+    String profileImageKey
 ) {
 
 }

--- a/member-service/src/main/java/com/example/memberservice/member/controller/dto/response/MemberGetResponse.java
+++ b/member-service/src/main/java/com/example/memberservice/member/controller/dto/response/MemberGetResponse.java
@@ -1,6 +1,7 @@
 package com.example.memberservice.member.controller.dto.response;
 
 
+import com.example.memberservice.common.client.dto.response.s3.PresignedDownloadResponse;
 import com.example.memberservice.member.service.model.vo.ApiMemberInfo;
 import com.example.memberservice.member.service.model.vo.MemberRating;
 import com.example.memberservice.member.service.model.vo.MemberTag;
@@ -15,7 +16,10 @@ public record MemberGetResponse(
     MemberRating rating,
 
     @Schema(description = "사용자 기술 태그 정보")
-    List<MemberTag> tags
+    List<MemberTag> tags,
+
+    @Schema(description = "사용자 프로필 이미지")
+    List<PresignedDownloadResponse> images
 ) {
 
 }

--- a/member-service/src/main/java/com/example/memberservice/member/controller/swagger/MemberApiControllerSwagger.java
+++ b/member-service/src/main/java/com/example/memberservice/member/controller/swagger/MemberApiControllerSwagger.java
@@ -25,14 +25,21 @@ public interface MemberApiControllerSwagger {
 
     @Operation(summary = "사용자 정보 조회", description = "사용자 정보를 조회합니다.")
     @Parameters({
-        @Parameter(name = "X-CODE", description = "로그인 사용자 코드", in = ParameterIn.HEADER, required = true),
         @Parameter(name = "member-code", description = "검색할 사용자 Code(없을 경우 본인 정보 검색)", in = ParameterIn.QUERY)
     })
     @ApiErrorResponses(exceptions = {ErrorCode.NOT_CONTAINS_MEMBER_CODE, ErrorCode.MEMBER_NOT_FOUND,
         ErrorCode.INTERNAL_SERVER_ERROR})
     ResponseDto<MemberGetResponse> getMemberByCode(
-        @RequestHeader(name = "X-CODE", required = false) String xCode,
         @RequestParam(name = "member-code", required = false) String paramCode);
+
+    @Operation(summary = "사용자 본인 정보 조회", description = "사용자 본인 정보를 조회합니다.")
+    @Parameters({
+        @Parameter(name = "X-CODE", description = "로그인 사용자 코드", in = ParameterIn.HEADER, required = true),
+    })
+    @ApiErrorResponses(exceptions = {ErrorCode.NOT_CONTAINS_MEMBER_CODE, ErrorCode.MEMBER_NOT_FOUND,
+        ErrorCode.INTERNAL_SERVER_ERROR})
+    ResponseDto<MemberGetResponse> getMyMemberByCode(
+        @RequestHeader(name = "X-CODE", required = false) String xCode);
 
     @Operation(summary = "사용자 생성", description = "새로운 사용자를 생성합니다.")
     @Parameters({
@@ -56,14 +63,16 @@ public interface MemberApiControllerSwagger {
         @Parameter(name = "X-CODE", description = "로그인한 사용자 코드", in = ParameterIn.HEADER, required = true)
     })
     @ApiErrorResponses(exceptions = {ErrorCode.MEMBER_NOT_FOUND})
-    ResponseDto<Empty> updateMemberRoleState(@RequestHeader("X-CODE") String memberCode, @RequestBody MemberRoleUpdateRequest request);
+    ResponseDto<Empty> updateMemberRoleState(@RequestHeader("X-CODE") String memberCode,
+        @RequestBody MemberRoleUpdateRequest request);
 
     @Operation(summary = "사용자 역할 제거", description = "사용자의 역할 제거를 진행합니다")
     @Parameters({
         @Parameter(name = "X-CODE", description = "로그인한 사용자 코드", in = ParameterIn.HEADER, required = true)
     })
     @ApiErrorResponses(exceptions = {ErrorCode.MEMBER_NOT_FOUND})
-    ResponseDto<Empty> deleteMemberRoleState(@RequestHeader("X-CODE") String memberCode, @RequestBody MemberRoleUpdateRequest request);
+    ResponseDto<Empty> deleteMemberRoleState(@RequestHeader("X-CODE") String memberCode,
+        @RequestBody MemberRoleUpdateRequest request);
 
     @Operation(summary = "사용자 삭제", description = "사용자를 삭제합니다.")
     @Parameters({

--- a/member-service/src/main/java/com/example/memberservice/member/mapper/MemberServiceInputMapper.java
+++ b/member-service/src/main/java/com/example/memberservice/member/mapper/MemberServiceInputMapper.java
@@ -3,20 +3,22 @@ package com.example.memberservice.member.mapper;
 import com.example.memberservice.member.controller.dto.request.MemberCreateRequest;
 import com.example.memberservice.member.controller.dto.request.MemberRoleUpdateRequest;
 import com.example.memberservice.member.controller.dto.request.MemberUpdateRequest;
+import com.example.memberservice.member.model.enums.MemberRole;
 import com.example.memberservice.member.service.model.dto.input.MemberCreateInput;
 import com.example.memberservice.member.service.model.dto.input.MemberDeleteInput;
 import com.example.memberservice.member.service.model.dto.input.MemberExistByNameInput;
 import com.example.memberservice.member.service.model.dto.input.MemberGetInput;
 import com.example.memberservice.member.service.model.dto.input.MemberUpdateInput;
 import com.example.memberservice.member.service.model.dto.input.MemberUpdateRoleStateInput;
+import org.hexagon.core.events.selfpromotion.SelfPromotionCreatedEvent;
 
 public final class MemberServiceInputMapper {
 
     private MemberServiceInputMapper() {
     }
 
-    public static MemberGetInput toGetMemberInput(String xCode, String paramCode) {
-        return new MemberGetInput(xCode, paramCode);
+    public static MemberGetInput toGetMemberInput(String memberCode) {
+        return new MemberGetInput(memberCode);
     }
 
     public static MemberCreateInput toCreateMemberInput(String memberCode,
@@ -49,9 +51,9 @@ public final class MemberServiceInputMapper {
     }
 
     //TODO(Profile 에서 카프카 메세지 구현 이후 의존)
-//    public static MemberUpdateRoleStateInput toUpdateMemberRoleStateInput(MemberRoleEvent event){
-//        return new MemberUpdateRoleStateInput(memberCode, event.role)
-//    }
+    public static MemberUpdateRoleStateInput toUpdateMemberRoleStateInput(SelfPromotionCreatedEvent event){
+        return new MemberUpdateRoleStateInput(event.memberCode(), MemberRole.FREELANCER);
+    }
 
     public static MemberDeleteInput toDeleteMemberInput(String memberCode) {
         return new MemberDeleteInput(memberCode);

--- a/member-service/src/main/java/com/example/memberservice/member/mapper/MemberServiceInputMapper.java
+++ b/member-service/src/main/java/com/example/memberservice/member/mapper/MemberServiceInputMapper.java
@@ -21,14 +21,26 @@ public final class MemberServiceInputMapper {
 
     public static MemberCreateInput toCreateMemberInput(String memberCode,
         MemberCreateRequest request) {
-        return new MemberCreateInput(memberCode, request.name(), request.phoneNumber(),
-            request.birthDate(), request.gender());
+        return new MemberCreateInput(
+            memberCode,
+            request.name(),
+            request.phoneNumber(),
+            request.birthDate(),
+            request.gender(),
+            request.profileImageKey()
+        );
     }
 
     public static MemberUpdateInput toUpdateMemberInput(String memberCode,
         MemberUpdateRequest request) {
-        return new MemberUpdateInput(memberCode, request.name(), request.phoneNumber(),
-            request.birthDate(), request.gender());
+        return new MemberUpdateInput(
+            memberCode,
+            request.name(),
+            request.phoneNumber(),
+            request.birthDate(),
+            request.gender(),
+            request.profileImageKey()
+        );
     }
 
     public static MemberUpdateRoleStateInput toUpdateMemberRoleStateInput(String memberCode,

--- a/member-service/src/main/java/com/example/memberservice/member/model/entity/Members.java
+++ b/member-service/src/main/java/com/example/memberservice/member/model/entity/Members.java
@@ -55,7 +55,7 @@ public class Members {
     @Comment("닉네임")
     private String nickName;
 
-    @Column(nullable = false)
+    @Column(nullable = false,unique = false)
     @Comment("이메일")
     private String email;
 

--- a/member-service/src/main/java/com/example/memberservice/member/service/MemberServiceImpl.java
+++ b/member-service/src/main/java/com/example/memberservice/member/service/MemberServiceImpl.java
@@ -2,7 +2,7 @@ package com.example.memberservice.member.service;
 
 import com.example.memberservice.auth.email.repository.EmailAuthRepository;
 import com.example.memberservice.common.client.ContractServiceClient;
-import com.example.memberservice.common.client.dto.response.ContractStateResponse;
+import com.example.memberservice.common.client.dto.response.contract.ContractStateResponse;
 import com.example.memberservice.common.exception.BusinessException;
 import com.example.memberservice.common.exception.ErrorCode;
 import com.example.memberservice.common.kafka.producer.MemberKafkaEventProducer;

--- a/member-service/src/main/java/com/example/memberservice/member/service/MemberServiceImpl.java
+++ b/member-service/src/main/java/com/example/memberservice/member/service/MemberServiceImpl.java
@@ -160,7 +160,13 @@ public class MemberServiceImpl implements MemberService {
         //회원 가입을 하기 전 이미 해당 nick name을 사용하는 사람이 있는 지 확인.
         checkNickNameDuplicate(input.memberCode(), input.name());
 
+        boolean updateEventTrigger = false;
+
         Members existMember = findMembers(input.memberCode());
+
+        if(!input.name().equals(existMember.getNickName())){
+            updateEventTrigger = true;
+        }
 
         MembersMapper.toApply(existMember, input);
 
@@ -171,8 +177,10 @@ public class MemberServiceImpl implements MemberService {
             List.of(input.profileImageKey())
         ));
 
-        memberKafkaEventProducer.sendUpdatedEvent(
-            new MemberUpdatedEvent(updatedMember.getCode(), updatedMember.getNickName()));
+        if(updateEventTrigger){
+            memberKafkaEventProducer.sendUpdatedEvent(
+                new MemberUpdatedEvent(updatedMember.getCode(), updatedMember.getNickName()));
+        }
     }
 
 

--- a/member-service/src/main/java/com/example/memberservice/member/service/MemberServiceImpl.java
+++ b/member-service/src/main/java/com/example/memberservice/member/service/MemberServiceImpl.java
@@ -2,11 +2,14 @@ package com.example.memberservice.member.service;
 
 import com.example.memberservice.auth.email.repository.EmailAuthRepository;
 import com.example.memberservice.common.client.ContractServiceClient;
+import com.example.memberservice.common.client.S3ServiceClient;
+import com.example.memberservice.common.client.dto.request.s3.StoreKeysRequest;
 import com.example.memberservice.common.client.dto.response.contract.ContractStateResponse;
 import com.example.memberservice.common.exception.BusinessException;
 import com.example.memberservice.common.exception.ErrorCode;
 import com.example.memberservice.common.kafka.producer.MemberKafkaEventProducer;
 import com.example.memberservice.member.model.enums.MemberRole;
+import org.hexagon.core.dto.Empty;
 import org.hexagon.core.dto.ResponseDto;
 import com.example.memberservice.member.controller.dto.response.MemberGetResponse;
 import com.example.memberservice.member.model.entity.Members;
@@ -62,6 +65,8 @@ public class MemberServiceImpl implements MemberService {
     private final EmailAuthRepository emailAuthRepository;
 
     private final ContractServiceClient contractServiceClient;
+
+    private final S3ServiceClient s3ServiceClient;
 
     //외부 API를 2개나 타기에 Transactional을 해주지 않습니다.
     @Override
@@ -121,7 +126,15 @@ public class MemberServiceImpl implements MemberService {
             .providerId(socialMembers.getProviderId())
             .build();
 
+
         Members savedMember = memberJpaRepository.save(newMember);
+
+        if(input.profileImageKey() != null && !input.profileImageKey().isBlank()) {
+            ResponseDto<Empty> emptyResponseDto = s3ServiceClient.updateKeys(new StoreKeysRequest(
+                savedMember.getCode(),
+                List.of(input.profileImageKey())
+            ));
+        }
 
         // Kafka Event 발송.
         memberKafkaEventProducer.sendCreatedEvent(new MemberCreatedEvent(savedMember.getCode()));
@@ -139,6 +152,11 @@ public class MemberServiceImpl implements MemberService {
         MembersMapper.toApply(existMember, input);
 
         Members updatedMember = memberJpaRepository.save(existMember);
+
+        ResponseDto<Empty> emptyResponseDto = s3ServiceClient.updateKeys(new StoreKeysRequest(
+            updatedMember.getCode(),
+            List.of(input.profileImageKey())
+        ));
 
         memberKafkaEventProducer.sendUpdatedEvent(
             new MemberUpdatedEvent(updatedMember.getCode(), updatedMember.getNickName()));

--- a/member-service/src/main/java/com/example/memberservice/member/service/MemberServiceImpl.java
+++ b/member-service/src/main/java/com/example/memberservice/member/service/MemberServiceImpl.java
@@ -3,12 +3,16 @@ package com.example.memberservice.member.service;
 import com.example.memberservice.auth.email.repository.EmailAuthRepository;
 import com.example.memberservice.common.client.ContractServiceClient;
 import com.example.memberservice.common.client.S3ServiceClient;
+import com.example.memberservice.common.client.dto.request.s3.PresignedDownloadRequestByCode;
 import com.example.memberservice.common.client.dto.request.s3.StoreKeysRequest;
 import com.example.memberservice.common.client.dto.response.contract.ContractStateResponse;
+import com.example.memberservice.common.client.dto.response.s3.PresignedDownloadListResponse;
+import com.example.memberservice.common.client.dto.response.s3.PresignedDownloadResponse;
 import com.example.memberservice.common.exception.BusinessException;
 import com.example.memberservice.common.exception.ErrorCode;
 import com.example.memberservice.common.kafka.producer.MemberKafkaEventProducer;
 import com.example.memberservice.member.model.enums.MemberRole;
+import java.io.DataOutput;
 import org.hexagon.core.dto.Empty;
 import org.hexagon.core.dto.ResponseDto;
 import com.example.memberservice.member.controller.dto.response.MemberGetResponse;
@@ -90,11 +94,21 @@ public class MemberServiceImpl implements MemberService {
 
         List<MemberTag> memberTags = null;
 
+        String memberProfileImageKey = null;
+
         memberRating = getMemberRating(findMemberCode);
 
         memberTags = getMemberTags(findMemberCode);
 
-        return new MemberGetResponse(memberInfo, memberRating, memberTags);
+        ResponseDto<PresignedDownloadListResponse> downloadUrlByCode = s3ServiceClient.getDownloadUrlByCode(
+            new PresignedDownloadRequestByCode(
+                existMembers.getCode()
+            )
+        );
+
+        List<PresignedDownloadResponse> urls = downloadUrlByCode.data().urls();
+
+        return new MemberGetResponse(memberInfo, memberRating, memberTags, urls);
     }
 
     @Override
@@ -126,10 +140,9 @@ public class MemberServiceImpl implements MemberService {
             .providerId(socialMembers.getProviderId())
             .build();
 
-
         Members savedMember = memberJpaRepository.save(newMember);
 
-        if(input.profileImageKey() != null && !input.profileImageKey().isBlank()) {
+        if (input.profileImageKey() != null && !input.profileImageKey().isBlank()) {
             ResponseDto<Empty> emptyResponseDto = s3ServiceClient.updateKeys(new StoreKeysRequest(
                 savedMember.getCode(),
                 List.of(input.profileImageKey())
@@ -211,10 +224,12 @@ public class MemberServiceImpl implements MemberService {
 
         Members updatedMember = memberJpaRepository.save(existMember);
 
-        if (inputRole.equals(MemberRole.CLIENT)){
-            memberKafkaEventProducer.sendDeletedClientRoleEvent(new MemberDeletedClientRoleEvent(updatedMember.getCode()));
-        }else{
-            memberKafkaEventProducer.sendDeletedFreelancerRoleEvent(new MemberDeletedFreelancerRoleEvent(updatedMember.getCode()));
+        if (inputRole.equals(MemberRole.CLIENT)) {
+            memberKafkaEventProducer.sendDeletedClientRoleEvent(
+                new MemberDeletedClientRoleEvent(updatedMember.getCode()));
+        } else {
+            memberKafkaEventProducer.sendDeletedFreelancerRoleEvent(
+                new MemberDeletedFreelancerRoleEvent(updatedMember.getCode()));
         }
     }
 

--- a/member-service/src/main/java/com/example/memberservice/member/service/MemberServiceImpl.java
+++ b/member-service/src/main/java/com/example/memberservice/member/service/MemberServiceImpl.java
@@ -2,17 +2,22 @@ package com.example.memberservice.member.service;
 
 import com.example.memberservice.auth.email.repository.EmailAuthRepository;
 import com.example.memberservice.common.client.ContractServiceClient;
+import com.example.memberservice.common.client.RatingServiceClient;
 import com.example.memberservice.common.client.S3ServiceClient;
+import com.example.memberservice.common.client.TagServiceClient;
 import com.example.memberservice.common.client.dto.request.s3.PresignedDownloadRequestByCode;
 import com.example.memberservice.common.client.dto.request.s3.StoreKeysRequest;
 import com.example.memberservice.common.client.dto.response.contract.ContractStateResponse;
+import com.example.memberservice.common.client.dto.response.rating.RatingResponse;
 import com.example.memberservice.common.client.dto.response.s3.PresignedDownloadListResponse;
 import com.example.memberservice.common.client.dto.response.s3.PresignedDownloadResponse;
+import com.example.memberservice.common.client.dto.response.tag.TagResponse;
 import com.example.memberservice.common.exception.BusinessException;
 import com.example.memberservice.common.exception.ErrorCode;
 import com.example.memberservice.common.kafka.producer.MemberKafkaEventProducer;
 import com.example.memberservice.member.model.enums.MemberRole;
-import java.io.DataOutput;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import org.hexagon.core.dto.Empty;
 import org.hexagon.core.dto.ResponseDto;
 import com.example.memberservice.member.controller.dto.response.MemberGetResponse;
@@ -28,11 +33,9 @@ import com.example.memberservice.member.service.model.dto.input.MemberUpdateRole
 import com.example.memberservice.member.service.model.vo.ApiMemberInfo;
 import com.example.memberservice.member.service.model.vo.MemberRating;
 import com.example.memberservice.member.service.model.vo.MemberTag;
-import com.example.memberservice.member.service.util.RequestURIGenerator;
 import com.example.memberservice.socialmember.entity.SocialMembers;
 import com.example.memberservice.socialmember.repository.SocialMemberJpaRepository;
 import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hexagon.core.events.member.MemberCreatedEvent;
@@ -40,31 +43,20 @@ import org.hexagon.core.events.member.MemberDeletedClientRoleEvent;
 import org.hexagon.core.events.member.MemberDeletedEvent;
 import org.hexagon.core.events.member.MemberDeletedFreelancerRoleEvent;
 import org.hexagon.core.events.member.MemberUpdatedEvent;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
     private final MemberJpaRepository memberJpaRepository;
 
     private final SocialMemberJpaRepository socialMemberJpaRepository;
 
-    // 멤버 조회에서 태그 정보와 평가 정보를 받아올 RestTemplate
-    private final RestTemplate restTemplate;
-
     //멤버 생성 및 업데이트 시 이벤트 발생 주체
     private final MemberKafkaEventProducer memberKafkaEventProducer;
-
-    private final RequestURIGenerator requestURIGenerator;
 
     private final EmailAuthRepository emailAuthRepository;
 
@@ -72,13 +64,34 @@ public class MemberServiceImpl implements MemberService {
 
     private final S3ServiceClient s3ServiceClient;
 
+    private final TagServiceClient tagServiceClient;
+
+    private final RatingServiceClient ratingServiceClient;
+
+    private final Executor externalApiExecutor;
+
+    public MemberServiceImpl(MemberJpaRepository memberJpaRepository,
+        SocialMemberJpaRepository socialMemberJpaRepository,
+        MemberKafkaEventProducer memberKafkaEventProducer, EmailAuthRepository emailAuthRepository,
+        ContractServiceClient contractServiceClient, S3ServiceClient s3ServiceClient,
+        TagServiceClient tagServiceClient, RatingServiceClient ratingServiceClient,
+        @Qualifier("externalApiExecutor") Executor externalApiExecutor) {
+        this.memberJpaRepository = memberJpaRepository;
+        this.socialMemberJpaRepository = socialMemberJpaRepository;
+        this.memberKafkaEventProducer = memberKafkaEventProducer;
+        this.emailAuthRepository = emailAuthRepository;
+        this.contractServiceClient = contractServiceClient;
+        this.s3ServiceClient = s3ServiceClient;
+        this.tagServiceClient = tagServiceClient;
+        this.ratingServiceClient = ratingServiceClient;
+        this.externalApiExecutor = externalApiExecutor;
+    }
+
     //외부 API를 2개나 타기에 Transactional을 해주지 않습니다.
     @Override
     public MemberGetResponse getMemberByCode(MemberGetInput input) {
 
-        String findMemberCode = (input.xCode() != null && !input.xCode().isBlank())
-            ? input.xCode()
-            : input.paramCode();
+        String findMemberCode =input.memberCode();
 
         if (findMemberCode == null || findMemberCode.isBlank()) {
             throw new BusinessException(ErrorCode.NOT_CONTAINS_MEMBER_CODE);
@@ -94,20 +107,33 @@ public class MemberServiceImpl implements MemberService {
 
         List<MemberTag> memberTags = null;
 
-        String memberProfileImageKey = null;
+        CompletableFuture<MemberRating> ratingFuture =
+            CompletableFuture.supplyAsync(
+                () -> getMemberRating(findMemberCode),
+                externalApiExecutor
+            );
 
-        memberRating = getMemberRating(findMemberCode);
+        CompletableFuture<List<MemberTag>> tagsFuture =
+            CompletableFuture.supplyAsync(
+                () -> getMemberTags(findMemberCode),
+                externalApiExecutor
+            );
 
-        memberTags = getMemberTags(findMemberCode);
+        CompletableFuture<ResponseDto<PresignedDownloadListResponse>> downloadFuture =
+            CompletableFuture.supplyAsync(
+                () -> s3ServiceClient.getDownloadUrlByCode(
+                    new PresignedDownloadRequestByCode(existMembers.getCode())
+                ),
+                externalApiExecutor
+            );
+        memberRating = ratingFuture.join();
 
-        ResponseDto<PresignedDownloadListResponse> downloadUrlByCode = s3ServiceClient.getDownloadUrlByCode(
-            new PresignedDownloadRequestByCode(
-                existMembers.getCode()
-            )
-        );
+        memberTags = tagsFuture.join();
+
+        ResponseDto<PresignedDownloadListResponse> downloadUrlByCode = downloadFuture.join();
 
         List<PresignedDownloadResponse> urls = downloadUrlByCode.data().urls();
-
+        
         return new MemberGetResponse(memberInfo, memberRating, memberTags, urls);
     }
 
@@ -143,7 +169,7 @@ public class MemberServiceImpl implements MemberService {
         Members savedMember = memberJpaRepository.save(newMember);
 
         if (input.profileImageKey() != null && !input.profileImageKey().isBlank()) {
-            ResponseDto<Empty> emptyResponseDto = s3ServiceClient.updateKeys(new StoreKeysRequest(
+            s3ServiceClient.updateKeys(new StoreKeysRequest(
                 savedMember.getCode(),
                 List.of(input.profileImageKey())
             ));
@@ -161,7 +187,7 @@ public class MemberServiceImpl implements MemberService {
         checkNickNameDuplicate(input.memberCode(), input.name());
 
         Members existMember = findMembers(input.memberCode());
-        
+
         //업데이트 이벤트는 NickName에 변화가 있을 때만 적용 
         boolean updateEventTrigger = !input.name().equals(existMember.getNickName());
 
@@ -171,10 +197,10 @@ public class MemberServiceImpl implements MemberService {
 
         ResponseDto<Empty> emptyResponseDto = s3ServiceClient.updateKeys(new StoreKeysRequest(
             updatedMember.getCode(),
-            (input.profileImageKey()==null)?List.of():List.of(input.profileImageKey()))
+            (input.profileImageKey() == null) ? List.of() : List.of(input.profileImageKey()))
         );
 
-        if(updateEventTrigger){
+        if (updateEventTrigger) {
             memberKafkaEventProducer.sendUpdatedEvent(
                 new MemberUpdatedEvent(updatedMember.getCode(), updatedMember.getNickName()));
         }
@@ -216,7 +242,6 @@ public class MemberServiceImpl implements MemberService {
 
         Members existMember = findMembers(input.memberCode());
 
-        //TODO(Contract에서 Internal API 구현시 해제)
         if (hasContractForRole(existMember, inputRole)) {
             throw new BusinessException(ErrorCode.CONTRACT_EXISTS);
         }
@@ -244,7 +269,7 @@ public class MemberServiceImpl implements MemberService {
         Members existMember = findMembers(input.memberCode());
 
         existMember.deletedMember();
-        //TODO(Contract에서 Internal API 구현시 해제)
+
         if (hasContractForRole(existMember, MemberRole.BOTH)) {
             throw new BusinessException(ErrorCode.CONTRACT_EXISTS);
         }
@@ -262,19 +287,17 @@ public class MemberServiceImpl implements MemberService {
     private List<MemberTag> getMemberTags(String findMemberCode) {
         List<MemberTag> memberTags;
         try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("X-CODE", findMemberCode); // 원하는 값 설정
-            HttpEntity<Void> entity = new HttpEntity<>(headers);
+            ResponseDto<List<TagResponse>> response = tagServiceClient.getMyTags(findMemberCode);
 
-            ResponseEntity<ResponseDto<List<MemberTag>>> response = restTemplate.exchange(
-                requestURIGenerator.gettagsUri(findMemberCode),
-                HttpMethod.GET,
-                entity,
-                new ParameterizedTypeReference<>() {
-                }
-            );
+            List<TagResponse> tagInfo = response.data();
 
-            memberTags = Objects.requireNonNull(response.getBody()).data();
+            memberTags = tagInfo.stream()
+                .map(tag -> new MemberTag(
+                    tag.tagCode(),
+                    tag.skill()
+                ))
+                .toList();
+
         } catch (Exception e) {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
@@ -284,15 +307,12 @@ public class MemberServiceImpl implements MemberService {
     private MemberRating getMemberRating(String findMemberCode) {
         MemberRating memberRating;
         try {
-            ResponseEntity<ResponseDto<MemberRating>> response = restTemplate.exchange(
-                requestURIGenerator.getRatingUri(findMemberCode),
-                HttpMethod.GET,
-                null,
-                new ParameterizedTypeReference<>() {
-                }
-            );
+            ResponseDto<RatingResponse> response = ratingServiceClient.getMemberRating(findMemberCode);
 
-            memberRating = Objects.requireNonNull(response.getBody()).data();
+            RatingResponse ratingInfo = response.data();
+
+            memberRating = new MemberRating(ratingInfo.memberCode(), ratingInfo.satisfiedCount(),
+                ratingInfo.unsatisfiedCount());
         } catch (Exception e) {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
         }

--- a/member-service/src/main/java/com/example/memberservice/member/service/MemberServiceImpl.java
+++ b/member-service/src/main/java/com/example/memberservice/member/service/MemberServiceImpl.java
@@ -160,13 +160,10 @@ public class MemberServiceImpl implements MemberService {
         //회원 가입을 하기 전 이미 해당 nick name을 사용하는 사람이 있는 지 확인.
         checkNickNameDuplicate(input.memberCode(), input.name());
 
-        boolean updateEventTrigger = false;
-
         Members existMember = findMembers(input.memberCode());
-
-        if(!input.name().equals(existMember.getNickName())){
-            updateEventTrigger = true;
-        }
+        
+        //업데이트 이벤트는 NickName에 변화가 있을 때만 적용 
+        boolean updateEventTrigger = !input.name().equals(existMember.getNickName());
 
         MembersMapper.toApply(existMember, input);
 
@@ -174,8 +171,8 @@ public class MemberServiceImpl implements MemberService {
 
         ResponseDto<Empty> emptyResponseDto = s3ServiceClient.updateKeys(new StoreKeysRequest(
             updatedMember.getCode(),
-            List.of(input.profileImageKey())
-        ));
+            (input.profileImageKey()==null)?List.of():List.of(input.profileImageKey()))
+        );
 
         if(updateEventTrigger){
             memberKafkaEventProducer.sendUpdatedEvent(

--- a/member-service/src/main/java/com/example/memberservice/member/service/mapper/MembersMapper.java
+++ b/member-service/src/main/java/com/example/memberservice/member/service/mapper/MembersMapper.java
@@ -13,7 +13,8 @@ public class MembersMapper {
             members.getEmail(),
             members.getPhoneNumber(),
             members.getBirthDate().toString(),
-            members.getGender().name()
+            members.getGender().name(),
+            members.getRole()
         );
     }
 

--- a/member-service/src/main/java/com/example/memberservice/member/service/model/dto/input/MemberCreateInput.java
+++ b/member-service/src/main/java/com/example/memberservice/member/service/model/dto/input/MemberCreateInput.java
@@ -12,5 +12,7 @@ public record MemberCreateInput(
 
     LocalDate birthDate,
 
-    Gender gender
+    Gender gender,
+
+    String profileImageKey
 ) {}

--- a/member-service/src/main/java/com/example/memberservice/member/service/model/dto/input/MemberGetInput.java
+++ b/member-service/src/main/java/com/example/memberservice/member/service/model/dto/input/MemberGetInput.java
@@ -1,6 +1,5 @@
 package com.example.memberservice.member.service.model.dto.input;
 
 public record MemberGetInput(
-    String xCode,
-    String paramCode
+    String memberCode
 ) {}

--- a/member-service/src/main/java/com/example/memberservice/member/service/model/dto/input/MemberUpdateInput.java
+++ b/member-service/src/main/java/com/example/memberservice/member/service/model/dto/input/MemberUpdateInput.java
@@ -12,7 +12,9 @@ public record MemberUpdateInput(
 
     LocalDate birthDate,
 
-    Gender gender
+    Gender gender,
+
+    String profileImageKey
 ) {
 
 }

--- a/member-service/src/main/java/com/example/memberservice/member/service/model/vo/ApiMemberInfo.java
+++ b/member-service/src/main/java/com/example/memberservice/member/service/model/vo/ApiMemberInfo.java
@@ -1,6 +1,7 @@
 package com.example.memberservice.member.service.model.vo;
 
 
+import com.example.memberservice.member.model.enums.MemberRole;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ApiMemberInfo(
@@ -21,7 +22,10 @@ public record ApiMemberInfo(
     String birthDay,
 
     @Schema(description = "사용자 성별", defaultValue = "MAN OR FEMAIL")
-    String gender
+    String gender,
+
+    @Schema(description = "사용자 역할", defaultValue = "FREELANCER")
+    MemberRole role
 
 ) {
 

--- a/member-service/src/test/java/com/example/memberservice/member/service/MemberServiceImplTest.java
+++ b/member-service/src/test/java/com/example/memberservice/member/service/MemberServiceImplTest.java
@@ -12,7 +12,9 @@ import static org.mockito.Mockito.when;
 
 import com.example.memberservice.auth.email.repository.EmailAuthRepository;
 import com.example.memberservice.common.client.ContractServiceClient;
+import com.example.memberservice.common.client.RatingServiceClient;
 import com.example.memberservice.common.client.S3ServiceClient;
+import com.example.memberservice.common.client.TagServiceClient;
 import com.example.memberservice.common.client.dto.response.contract.ContractStateResponse;
 import com.example.memberservice.common.client.dto.response.s3.PresignedDownloadListResponse;
 import com.example.memberservice.common.exception.BusinessException;
@@ -35,6 +37,7 @@ import com.example.memberservice.socialmember.repository.SocialMemberJpaReposito
 import java.time.LocalDate;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import org.hexagon.core.dto.ResponseDto;
 import org.hexagon.core.events.member.MemberCreatedEvent;
 import org.hexagon.core.events.member.MemberUpdatedEvent;
@@ -66,13 +69,7 @@ class MemberServiceImplTest {
     private MemberServiceImpl service;
 
     @MockitoBean
-    private RestTemplate restTemplate; // 외부 API는 Mock
-
-    @MockitoBean
     private MemberKafkaEventProducer memberKafkaEventProducer;
-
-    @MockitoBean
-    private RequestURIGenerator requestURIGenerator;
 
     @MockitoBean
     private KafkaAdmin kafkaAdmin;
@@ -86,19 +83,28 @@ class MemberServiceImplTest {
     @MockitoBean
     private S3ServiceClient s3ServiceClient;
 
+    @MockitoBean
+    private TagServiceClient tagServiceClient;
+
+    @MockitoBean
+    private RatingServiceClient ratingServiceClient;
+
     private MemberService memberService;
 
     @BeforeEach
     void setUp() {
+        Executor testExecutor = Runnable::run;
+
         memberService = new MemberServiceImpl(
             memberJpaRepository,
             socialMemberJpaRepository,
-            restTemplate,
             memberKafkaEventProducer,
-            requestURIGenerator,
             emailAuthRepository,
             contractServiceClient,
-            s3ServiceClient
+            s3ServiceClient,
+            tagServiceClient,
+            ratingServiceClient,
+            testExecutor
         );
 
         when(s3ServiceClient.getDownloadUrlByCode(any())).thenReturn(ResponseDto.success(new PresignedDownloadListResponse(List.of())));
@@ -116,7 +122,7 @@ class MemberServiceImplTest {
     @Test
     @DisplayName("getMemberByCode: 코드 없으면 예외")
     void getMemberByCode_noCode() {
-        MemberGetInput input = new MemberGetInput("", "");
+        MemberGetInput input = new MemberGetInput("");
 
         assertThatThrownBy(() -> service.getMemberByCode(input))
             .isInstanceOf(BusinessException.class)

--- a/member-service/src/test/java/com/example/memberservice/member/service/MemberServiceImplTest.java
+++ b/member-service/src/test/java/com/example/memberservice/member/service/MemberServiceImplTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.when;
 
 import com.example.memberservice.auth.email.repository.EmailAuthRepository;
 import com.example.memberservice.common.client.ContractServiceClient;
-import com.example.memberservice.common.client.dto.response.ContractStateResponse;
+import com.example.memberservice.common.client.dto.response.contract.ContractStateResponse;
 import com.example.memberservice.common.exception.BusinessException;
 import com.example.memberservice.common.exception.ErrorCode;
 import com.example.memberservice.common.kafka.producer.MemberKafkaEventProducer;
@@ -37,7 +37,6 @@ import org.hexagon.core.dto.ResponseDto;
 import org.hexagon.core.events.member.MemberCreatedEvent;
 import org.hexagon.core.events.member.MemberUpdatedEvent;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/member-service/src/test/java/com/example/memberservice/member/service/MemberServiceImplTest.java
+++ b/member-service/src/test/java/com/example/memberservice/member/service/MemberServiceImplTest.java
@@ -12,7 +12,9 @@ import static org.mockito.Mockito.when;
 
 import com.example.memberservice.auth.email.repository.EmailAuthRepository;
 import com.example.memberservice.common.client.ContractServiceClient;
+import com.example.memberservice.common.client.S3ServiceClient;
 import com.example.memberservice.common.client.dto.response.contract.ContractStateResponse;
+import com.example.memberservice.common.client.dto.response.s3.PresignedDownloadListResponse;
 import com.example.memberservice.common.exception.BusinessException;
 import com.example.memberservice.common.exception.ErrorCode;
 import com.example.memberservice.common.kafka.producer.MemberKafkaEventProducer;
@@ -81,6 +83,9 @@ class MemberServiceImplTest {
     @MockitoBean
     private ContractServiceClient contractServiceClient;
 
+    @MockitoBean
+    private S3ServiceClient s3ServiceClient;
+
     private MemberService memberService;
 
     @BeforeEach
@@ -92,8 +97,14 @@ class MemberServiceImplTest {
             memberKafkaEventProducer,
             requestURIGenerator,
             emailAuthRepository,
-            contractServiceClient
+            contractServiceClient,
+            s3ServiceClient
         );
+
+        when(s3ServiceClient.getDownloadUrlByCode(any())).thenReturn(ResponseDto.success(new PresignedDownloadListResponse(List.of())));
+
+        when(s3ServiceClient.updateKeys(any())).thenReturn(ResponseDto.success());
+
     }
 
     @AfterEach
@@ -122,7 +133,7 @@ class MemberServiceImplTest {
             memberJpaRepository.save(m);
 
             MemberCreateInput input = new MemberCreateInput(m.getCode(), "nick", "010100200",
-                LocalDate.now(), Gender.MAN);
+                LocalDate.now(), Gender.MAN,null);
             assertThatThrownBy(() -> service.createMember(input))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.MEMBER_ALREADY_EXISTS.getMessage());
@@ -135,7 +146,7 @@ class MemberServiceImplTest {
             memberJpaRepository.save(m);
 
             MemberCreateInput input = new MemberCreateInput("c1", m.getNickName(), "010100200",
-                LocalDate.now(), Gender.MAN);
+                LocalDate.now(), Gender.MAN,null);
 
             assertThatThrownBy(() -> service.createMember(input))
                 .isInstanceOf(BusinessException.class)
@@ -146,7 +157,7 @@ class MemberServiceImplTest {
         @DisplayName("createMember: 소셜멤버 없으면 예외")
         void createMember_noSocialMember() {
             MemberCreateInput input = new MemberCreateInput("who", "nick", "010100200", LocalDate.now(),
-                Gender.MAN);
+                Gender.MAN,null);
 
             assertThatThrownBy(() -> service.createMember(input))
                 .isInstanceOf(BusinessException.class)
@@ -162,7 +173,7 @@ class MemberServiceImplTest {
             SocialMembers save = socialMemberJpaRepository.save(socialMembers);
 
             MemberCreateInput input = new MemberCreateInput(save.getCode(), "new", "01022223333",
-                LocalDate.now(), Gender.MAN);
+                LocalDate.now(), Gender.MAN,null);
             given(memberKafkaEventProducer.sendCreatedEvent(any(MemberCreatedEvent.class)))
                 .willReturn(CompletableFuture.completedFuture(null));
 
@@ -189,7 +200,7 @@ class MemberServiceImplTest {
             memberJpaRepository.saveAll(List.of(m, m2));
 
             MemberUpdateInput input = new MemberUpdateInput("c1", "worker", "01099998888",
-                LocalDate.now(), Gender.MAN);
+                LocalDate.now(), Gender.MAN,null);
 
             assertThatThrownBy(() -> service.updateMember(input))
                 .isInstanceOf(BusinessException.class)
@@ -203,7 +214,7 @@ class MemberServiceImplTest {
             memberJpaRepository.save(m);
 
             MemberUpdateInput input = new MemberUpdateInput(m.getCode(), "newNick", "01087901234",
-                LocalDate.now(), Gender.MAN);
+                LocalDate.now(), Gender.MAN,null);
             given(memberKafkaEventProducer.sendUpdatedEvent(any(MemberUpdatedEvent.class)))
                 .willReturn(CompletableFuture.completedFuture(null));
 


### PR DESCRIPTION
## 🐛 관련 이슈
 <!-- Closes #{이슈-번호} 형태로 작성하세요 (ex: Closes #134) -->
Closes #184 

## 📌 목적
최종 프로젝트 멤버 모듈 프로필 이미지가 추가됨에 따라,
해당 이미지를 다룰 수 있도록
- 멤버 조회
- 회원 가입
- 회원 정보 수정 시

S3 Key와 관련된 정보를 입력으로 받고

해당 Key를 통해 S3 모듈과 통신하는 FeignClient를 구성하였습니다.

## ✅ 변경 사항
- 회원가입, 유저 정보 변경 시 s3 이미지 변경.
- 회원 조회 시 DownloadUrl을 조합할 수 있는 Key, QueryString, filetype 반환
- 유저 정보 변경 시 nickName에 변화가 있을 때만 UpdateEvent가 전송되도록 리팩토링


### 1️⃣ 회원 가입과 유저 정보 변경 시 S3 모듈 요청 보내는 차이
```
회원 가입 시
if (input.profileImageKey() != null && !input.profileImageKey().isBlank()) {
            ResponseDto<Empty> emptyResponseDto = s3ServiceClient.updateKeys(new StoreKeysRequest(
                savedMember.getCode(),
                List.of(input.profileImageKey())
            ));
        }
```

```
회원 정보 업데이트 시 

  ResponseDto<Empty> emptyResponseDto = s3ServiceClient.updateKeys(new StoreKeysRequest(
            updatedMember.getCode(),
            (input.profileImageKey()==null)?List.of():List.of(input.profileImageKey()))
        );

```

회원 가입 시에는 null 일 경우에는 s3 모듈로 통신을 할 필요가 없지만

회원 정보 업데이트 시에 null 일 경우 기존에 있던 이미지가 삭제된 것인지,
원래 null 인지를 알 수 없어 차이가 존재합니다.

### 2️⃣ 회원 정보 업데이트 시 nick name에 변화가 있을 때만 Update 이벤트 전송
기존 회원 정보 업데이트 이벤트를 발생 했던 이유가

NickName에 변경이 있을 때 Self-Promotion과 commision 의 영향을 미치기 때문이었는데 
현재 코드 상으론 nick name에 변화가 없어도 Update 이벤트를 보내고 있어 
불필요한 이벤트 처리가 반복되고 있었습니다. 그래서 Update시 닉네임의 변화를 확인하여 

변화가 있을 때만 nickName을 변경시켜줍니다.

## 🧪 테스트 방법
- S3 모듈과 연관된 내용이라 외부 통신과 관련한 테스트를 제외하였습니다.

## 📎 참고 사항
- 관련 이슈 번호 : 155
- 화면 캡처, 참고 문서 등

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [ ] 이슈 번호를 입력 했나요?
- [ ] 코드 컨벤션을 모두 지켰나요?
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
