### PR TITLE
feat(chat): 파일 메시지 조회 기능 구현

### DIFF
--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/FileInfo.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/FileInfo.java
@@ -1,6 +1,0 @@
-package com.example.communicationservice.controller.dto;
-
-public record FileInfo(
-    String key
-) {
-}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatFileReadResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatFileReadResponse.java
@@ -1,0 +1,10 @@
+package com.example.communicationservice.controller.dto.response;
+
+import org.hexagon.core.vo.FileType;
+
+public record ChatFileReadResponse(
+    String key,
+    String queryString, // pre-signed download URL 구성 요소
+    FileType fileType
+) {
+}

--- a/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageReadResponse.java
+++ b/communication-service/src/main/java/com/example/communicationservice/controller/dto/response/ChatMessageReadResponse.java
@@ -1,6 +1,5 @@
 package com.example.communicationservice.controller.dto.response;
 
-import com.example.communicationservice.controller.dto.FileInfo;
 import com.example.communicationservice.type.MessageType;
 
 import java.time.Instant;
@@ -10,7 +9,7 @@ public record ChatMessageReadResponse(
     String senderCode,
     MessageType type,
     String text,
-    FileInfo file,
+    ChatFileReadResponse file,
     Instant sentAt
 ) {
 }

--- a/communication-service/src/main/java/com/example/communicationservice/mapper/ChatMapper.java
+++ b/communication-service/src/main/java/com/example/communicationservice/mapper/ChatMapper.java
@@ -1,13 +1,14 @@
 package com.example.communicationservice.mapper;
 
+import com.example.communicationservice.client.dto.output.FileDownloadUrlGenerateOutput;
 import com.example.communicationservice.client.dto.output.FileDownloadUrlListGenerateOutput;
 import com.example.communicationservice.controller.dto.request.ChatMessageSendRequest;
-import com.example.communicationservice.controller.dto.response.ChatMessageReadResponse;
-import com.example.communicationservice.controller.dto.response.ChatMessageSendResponse;
-import com.example.communicationservice.controller.dto.response.ChatRoomCreateResponse;
-import com.example.communicationservice.controller.dto.response.ChatRoomReadResponse;
+import com.example.communicationservice.controller.dto.response.*;
 import com.example.communicationservice.entity.ChatMessage;
 import com.example.communicationservice.entity.ChatRoom;
+import com.example.communicationservice.type.MessageType;
+
+import java.util.Map;
 
 // dto <-> entity 또는 dto <-> dto 변환 로직 전담
 public abstract class ChatMapper {
@@ -26,13 +27,28 @@ public abstract class ChatMapper {
             .build();
     }
 
-    public static ChatMessageReadResponse toReadResponse(ChatMessage message) {
+    public static ChatMessageReadResponse toReadResponse(
+        ChatMessage message,
+        Map<String, FileDownloadUrlGenerateOutput> keyToDownloadUrl
+    ) {
+        ChatFileReadResponse file = null;
+        MessageType type = message.getType();
+
+        if (message.getFile() != null && (MessageType.FILE == type || MessageType.MIXED == type)) {
+            String key = message.getFile().getKey();
+            FileDownloadUrlGenerateOutput output = keyToDownloadUrl.get(key);
+
+            if (output != null) {
+                file = FileMapper.toReadResponse(output);
+            }
+        }
+
         return new ChatMessageReadResponse(
             message.getId(),
             message.getSenderCode(),
             message.getType(),
             message.getText(),
-            FileMapper.from(message.getFile()),
+            file,
             message.getSentAt()
         );
     }
@@ -47,7 +63,7 @@ public abstract class ChatMapper {
             message.getSenderCode(),
             message.getType(),
             message.getText(),
-            output != null ? FileMapper.from(output.urls().get(0)) : null,
+            output != null ? FileMapper.toSendResponse(output.urls().get(0)) : null,
             message.getSentAt()
         );
     }

--- a/communication-service/src/main/java/com/example/communicationservice/mapper/ChatMapper.java
+++ b/communication-service/src/main/java/com/example/communicationservice/mapper/ChatMapper.java
@@ -1,7 +1,6 @@
 package com.example.communicationservice.mapper;
 
 import com.example.communicationservice.client.dto.output.FileDownloadUrlGenerateOutput;
-import com.example.communicationservice.client.dto.output.FileDownloadUrlListGenerateOutput;
 import com.example.communicationservice.controller.dto.request.ChatMessageSendRequest;
 import com.example.communicationservice.controller.dto.response.*;
 import com.example.communicationservice.entity.ChatMessage;
@@ -55,7 +54,7 @@ public abstract class ChatMapper {
 
     public static ChatMessageSendResponse toSendResponse(
         ChatMessage message,
-        FileDownloadUrlListGenerateOutput output
+        FileDownloadUrlGenerateOutput output
     ) {
         return new ChatMessageSendResponse(
             message.getId(),
@@ -63,7 +62,7 @@ public abstract class ChatMapper {
             message.getSenderCode(),
             message.getType(),
             message.getText(),
-            output != null ? FileMapper.toSendResponse(output.urls().get(0)) : null,
+            output != null ? FileMapper.toSendResponse(output) : null,
             message.getSentAt()
         );
     }

--- a/communication-service/src/main/java/com/example/communicationservice/mapper/FileMapper.java
+++ b/communication-service/src/main/java/com/example/communicationservice/mapper/FileMapper.java
@@ -13,15 +13,11 @@ public abstract class FileMapper {
 
     private FileMapper() {} // 인스턴스화 방지
 
-    public static ChatFileReadResponse from(File file) {
-        if (file == null) {
-            return null;
-        }
-
+    public static ChatFileReadResponse toReadResponse(FileDownloadUrlGenerateOutput output) {
         return new ChatFileReadResponse(
-            file.getKey(),
-            null, // queryString
-            null // fileType
+            output.key(),
+            output.queryString(),
+            output.fileType()
         );
     }
 
@@ -42,7 +38,7 @@ public abstract class FileMapper {
         );
     }
 
-    public static ChatFileSendResponse from(FileDownloadUrlGenerateOutput output) {
+    public static ChatFileSendResponse toSendResponse(FileDownloadUrlGenerateOutput output) {
         return new ChatFileSendResponse(
             output.key(),
             output.queryString(),

--- a/communication-service/src/main/java/com/example/communicationservice/mapper/FileMapper.java
+++ b/communication-service/src/main/java/com/example/communicationservice/mapper/FileMapper.java
@@ -2,7 +2,7 @@ package com.example.communicationservice.mapper;
 
 import com.example.communicationservice.client.dto.output.FileDownloadUrlGenerateOutput;
 import com.example.communicationservice.client.dto.output.FileUploadUrlGenerateOutput;
-import com.example.communicationservice.controller.dto.FileInfo;
+import com.example.communicationservice.controller.dto.response.ChatFileReadResponse;
 import com.example.communicationservice.controller.dto.request.ChatFileSendRequest;
 import com.example.communicationservice.controller.dto.response.ChatFileSendResponse;
 import com.example.communicationservice.controller.dto.response.ChatFileUploadUrlGenerateResponse;
@@ -13,12 +13,16 @@ public abstract class FileMapper {
 
     private FileMapper() {} // 인스턴스화 방지
 
-    public static FileInfo from(File file) {
+    public static ChatFileReadResponse from(File file) {
         if (file == null) {
             return null;
         }
 
-        return new FileInfo(file.getKey());
+        return new ChatFileReadResponse(
+            file.getKey(),
+            null, // queryString
+            null // fileType
+        );
     }
 
     public static File toEntity(ChatFileSendRequest request) {

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
@@ -2,6 +2,7 @@ package com.example.communicationservice.service;
 
 import com.example.communicationservice.client.S3ServiceClient;
 import com.example.communicationservice.client.dto.input.FileDownloadUrlGenerateInput;
+import com.example.communicationservice.client.dto.output.FileDownloadUrlGenerateOutput;
 import com.example.communicationservice.client.dto.output.FileDownloadUrlListGenerateOutput;
 import com.example.communicationservice.common.exception.ChatRoomException;
 import com.example.communicationservice.common.status.ResponseDtoStatus;
@@ -12,6 +13,7 @@ import com.example.communicationservice.controller.dto.response.ChatMessageSendR
 import com.example.communicationservice.controller.dto.response.PageInfo;
 import com.example.communicationservice.entity.ChatMessage;
 import com.example.communicationservice.entity.ChatRoom;
+import com.example.communicationservice.entity.File;
 import com.example.communicationservice.mapper.ChatMapper;
 import com.example.communicationservice.mapper.PageMapper;
 import com.example.communicationservice.repository.ChatMessageRepository;
@@ -24,6 +26,10 @@ import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -52,12 +58,47 @@ public class ChatMessageService {
 
         Page<ChatMessage> messagePage = chatMessageRepository.findAllByRoomId(roomId, pageable);
 
-        // 엔티티 -> DTO 변환
-        List<ChatMessageReadResponse> messages = messagePage.getContent().stream()
-            .map(ChatMapper::toReadResponse)
+        // 파일이 포함된 메시지에서 key 추출 후 리스트에 저장
+        List<String> keys = messagePage.getContent().stream()
+            .filter(message ->
+                MessageType.FILE == message.getType() ||
+                MessageType.MIXED == message.getType()
+            ) // 파일이 포함된 메시지만 필터링
+            .map(ChatMessage::getFile)
+            .filter(Objects::nonNull)
+            .map(File::getKey) // key 추출
+            .distinct() // 동일 파일 중복 방지
             .toList();
 
-        // Page 정보 추출 및 DTO 생성
+        // key: 파일 key, value: pre-signed download URL 생성 응답
+        // lambda 함수에서 참조되는 read-only 데이터이므로 final 선언
+        final Map<String, FileDownloadUrlGenerateOutput> keyToDownloadUrl;
+
+        if (!keys.isEmpty()) {
+            // feign client 요청 dto 생성
+            FileDownloadUrlGenerateInput input = new FileDownloadUrlGenerateInput(keys);
+
+            // S3 service에 pre-signed download URL 발급 요청
+            FileDownloadUrlListGenerateOutput output = s3ServiceClient.generateDownloadUrl(input).data();
+
+            // 파일 key에 pre-signed download URL 생성 응답 매핑
+            keyToDownloadUrl = output.urls().stream()
+                .collect(
+                    Collectors.toMap(
+                        FileDownloadUrlGenerateOutput::key, // key
+                        Function.identity() // value // 입력으로 받은 FileDownloadUrlGenerateOutput을 그대로 반환
+                    )
+                );
+        } else {
+            keyToDownloadUrl = Map.of();
+        }
+
+        // 엔티티 -> dto 변환
+        List<ChatMessageReadResponse> messages = messagePage.getContent().stream()
+            .map(message -> ChatMapper.toReadResponse(message, keyToDownloadUrl))
+            .toList();
+
+        // Page 정보 추출 및 dto 생성
         PageInfo pageInfo = PageMapper.toPageInfo(messagePage);
 
         return new ChatMessageListReadResponse(messages, pageInfo);

--- a/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
+++ b/communication-service/src/main/java/com/example/communicationservice/service/ChatMessageService.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -59,39 +60,10 @@ public class ChatMessageService {
         Page<ChatMessage> messagePage = chatMessageRepository.findAllByRoomId(roomId, pageable);
 
         // 파일이 포함된 메시지에서 key 추출 후 리스트에 저장
-        List<String> keys = messagePage.getContent().stream()
-            .filter(message ->
-                MessageType.FILE == message.getType() ||
-                MessageType.MIXED == message.getType()
-            ) // 파일이 포함된 메시지만 필터링
-            .map(ChatMessage::getFile)
-            .filter(Objects::nonNull)
-            .map(File::getKey) // key 추출
-            .distinct() // 동일 파일 중복 방지
-            .toList();
+        List<String> keys = extractFileKeys(messagePage.getContent());
 
         // key: 파일 key, value: pre-signed download URL 생성 응답
-        // lambda 함수에서 참조되는 read-only 데이터이므로 final 선언
-        final Map<String, FileDownloadUrlGenerateOutput> keyToDownloadUrl;
-
-        if (!keys.isEmpty()) {
-            // feign client 요청 dto 생성
-            FileDownloadUrlGenerateInput input = new FileDownloadUrlGenerateInput(keys);
-
-            // S3 service에 pre-signed download URL 발급 요청
-            FileDownloadUrlListGenerateOutput output = s3ServiceClient.generateDownloadUrl(input).data();
-
-            // 파일 key에 pre-signed download URL 생성 응답 매핑
-            keyToDownloadUrl = output.urls().stream()
-                .collect(
-                    Collectors.toMap(
-                        FileDownloadUrlGenerateOutput::key, // key
-                        Function.identity() // value // 입력으로 받은 FileDownloadUrlGenerateOutput을 그대로 반환
-                    )
-                );
-        } else {
-            keyToDownloadUrl = Map.of();
-        }
+        Map<String, FileDownloadUrlGenerateOutput> keyToDownloadUrl = generateDownloadUrlMap(keys);
 
         // 엔티티 -> dto 변환
         List<ChatMessageReadResponse> messages = messagePage.getContent().stream()
@@ -131,29 +103,74 @@ public class ChatMessageService {
         chatRoom.setUpdatedAt(Instant.now());
         chatRoomRepository.save(chatRoom);
 
+        FileDownloadUrlGenerateOutput output = null;
+
         // pre-signed download URL 생성
-        FileDownloadUrlListGenerateOutput output = generateDownloadUrl(request);
+        if (hasFile(request.type())) {
+            output = generateSingleDownloadUrl(request.file().key()).orElse(null);
+        }
 
         return ChatMapper.toSendResponse(savedChatMessage, output);
     }
 
+    private boolean hasFile(MessageType type) {
+        return MessageType.FILE == type || MessageType.MIXED == type;
+    }
+
     /**
-     * s3 service와 통신해 pre-signed download URL을 생성합니다.
-     * @param request 저장할 채팅 메시지 전송 요청
+     * s3 service와 통신해 단일 파일에 대한 pre-signed download URL을 생성합니다.
+     * @param key pre-signed download URL을 생성할 파일 key
      * @return pre-signed download URL 생성 응답
      */
-    private FileDownloadUrlListGenerateOutput generateDownloadUrl(ChatMessageSendRequest request) {
-        // 파일이 포함되지 않은 메시지인 경우 early return
-        if (MessageType.FILE != request.type() && MessageType.MIXED != request.type()) {
-            return null;
-        }
-
+    private Optional<FileDownloadUrlGenerateOutput> generateSingleDownloadUrl(String key) {
         // feign client 요청 dto 생성
-        String key = request.file().key();
         FileDownloadUrlGenerateInput input = new FileDownloadUrlGenerateInput(List.of(key));
 
         // S3 service에 pre-signed download URL 발급 요청
-        return s3ServiceClient.generateDownloadUrl(input).data();
+        FileDownloadUrlListGenerateOutput output = s3ServiceClient.generateDownloadUrl(input).data();
+
+        return output.urls().stream().findFirst();
+    }
+
+    /**
+     * 채팅 메시지 목록에서 파일이 포함된 메시지의 파일 key를 추출합니다.
+     * @param messages 채팅 메시지 목록
+     * @return 파일이 포함된 메시지에서 추출한 파일 key 목록
+     */
+    private List<String> extractFileKeys(List<ChatMessage> messages) {
+        return messages.stream()
+            .filter(message -> hasFile(message.getType())) // 파일이 포함된 메시지만 필터링
+            .map(ChatMessage::getFile)
+            .filter(Objects::nonNull)
+            .map(File::getKey) // key 추출
+            .distinct() // 동일 파일 중복 방지
+            .toList();
+    }
+
+    /**
+     * S3 service와 통신해 다중 파일에 대한 pre-signed download URL 매핑 정보를 생성합니다.
+     * @param keys pre-signed download URL을 생성할 파일 key 목록
+     * @return 파일 key 기반 pre-signed download URL 매핑 정보
+     */
+    private Map<String, FileDownloadUrlGenerateOutput> generateDownloadUrlMap(List<String> keys) {
+        if (keys.isEmpty()) {
+            return Map.of();
+        }
+
+        // feign client 요청 dto 생성
+        FileDownloadUrlGenerateInput input = new FileDownloadUrlGenerateInput(keys);
+
+        // S3 service에 pre-signed download URL 발급 요청
+        FileDownloadUrlListGenerateOutput output = s3ServiceClient.generateDownloadUrl(input).data();
+
+        // 파일 key에 pre-signed download URL 생성 응답 매핑
+        return output.urls().stream()
+            .collect(
+                Collectors.toMap(
+                    FileDownloadUrlGenerateOutput::key, // key
+                    Function.identity() // value // 입력으로 받은 FileDownloadUrlGenerateOutput을 그대로 반환
+                )
+            );
     }
 
 }

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
@@ -67,8 +67,8 @@ class ChatMessageServiceTest {
         ChatRoom chatRoom = createMockChatRoom(List.of(MY_CODE, PARTNER_CODE));
         Pageable pageable = PageRequest.of(0, 10);
 
-        ChatMessage message1 = createMockMessage("안녕하세요", MY_CODE);
-        ChatMessage message2 = createMockMessage("반갑습니다", PARTNER_CODE);
+        ChatMessage message1 = createMockTextMessage("안녕하세요", MY_CODE);
+        ChatMessage message2 = createMockTextMessage("반갑습니다", PARTNER_CODE);
 
         List<ChatMessage> messages = List.of(message1, message2);
 
@@ -137,14 +137,9 @@ class ChatMessageServiceTest {
     @Test
     void 채팅방_메시지를_저장하고_채팅방_업데이트_시간을_갱신한다() {
         // given
-        String messageId = "saved-msg-id-1";
         ChatRoom chatRoom = createMockChatRoom(List.of(MY_CODE, PARTNER_CODE));
-        ChatMessage savedMessage = ChatMessage.builder()
-            .roomId(ROOM_ID)
-            .senderCode(MY_CODE)
-            .type(MessageType.TEXT)
-            .text(CHAT_TEXT)
-            .build();
+        ChatMessage savedMessage = createMockTextMessage(CHAT_TEXT, MY_CODE);
+
         ChatMessageSendRequest request = new ChatMessageSendRequest(
             ROOM_ID,
             MY_CODE,
@@ -152,9 +147,6 @@ class ChatMessageServiceTest {
             CHAT_TEXT,
             null
         );
-
-        ReflectionTestUtils.setField(savedMessage, "id", messageId);
-        ReflectionTestUtils.setField(savedMessage, "sentAt", Instant.now());
 
         given(chatRoomRepository.findById(eq(ROOM_ID)))
             .willReturn(Optional.of(chatRoom));
@@ -166,7 +158,6 @@ class ChatMessageServiceTest {
 
         // then
         assertThat(response).isNotNull();
-        assertThat(response.messageId()).isEqualTo(messageId);
         assertThat(response.text()).isEqualTo(CHAT_TEXT);
 
         verify(chatRoomRepository, times(1)).findById(eq(ROOM_ID));
@@ -203,6 +194,7 @@ class ChatMessageServiceTest {
         // given
         String unauthorizedUser = "UNAUTHORIZED_USER";
         ChatRoom chatRoom = createMockChatRoom(List.of(MY_CODE, PARTNER_CODE));
+
         ChatMessageSendRequest request = new ChatMessageSendRequest(
             ROOM_ID,
             unauthorizedUser,
@@ -229,8 +221,7 @@ class ChatMessageServiceTest {
         // given
         ChatRoom chatRoom = createMockChatRoom(List.of(MY_CODE, PARTNER_CODE));
         Pageable pageable = PageRequest.of(0, 10);
-
-        ChatMessage textMessage = createMockMessage("텍스트 메시지", MY_CODE);
+        ChatMessage textMessage = createMockTextMessage("텍스트 메시지", MY_CODE);
 
         Page<ChatMessage> mockPage = new PageImpl<>(
             List.of(textMessage),
@@ -261,20 +252,7 @@ class ChatMessageServiceTest {
         String queryString = "?query=string";
         ChatRoom chatRoom = createMockChatRoom(List.of(MY_CODE, PARTNER_CODE));
         Pageable pageable = PageRequest.of(0, 10);
-
-        File file = File.builder()
-            .key(key)
-            .build();
-
-        ChatMessage fileMessage = ChatMessage.builder()
-            .roomId(ROOM_ID)
-            .senderCode(MY_CODE)
-            .type(MessageType.FILE)
-            .file(file)
-            .build();
-
-        ReflectionTestUtils.setField(fileMessage, "id", "file-msg-1");
-        ReflectionTestUtils.setField(fileMessage, "sentAt", Instant.now());
+        ChatMessage fileMessage = createMockFileMessage(key, MY_CODE);
 
         Page<ChatMessage> mockPage = new PageImpl<>(
             List.of(fileMessage),
@@ -316,21 +294,7 @@ class ChatMessageServiceTest {
         String queryString = "?query=string";
         ChatRoom chatRoom = createMockChatRoom(List.of(MY_CODE, PARTNER_CODE));
         Pageable pageable = PageRequest.of(0, 10);
-
-        File file = File.builder()
-            .key(key)
-            .build();
-
-        ChatMessage mixedMessage = ChatMessage.builder()
-            .roomId(ROOM_ID)
-            .senderCode(PARTNER_CODE)
-            .type(MessageType.MIXED)
-            .text(CHAT_TEXT)
-            .file(file)
-            .build();
-
-        ReflectionTestUtils.setField(mixedMessage, "id", "mixed-msg-1");
-        ReflectionTestUtils.setField(mixedMessage, "sentAt", Instant.now());
+        ChatMessage mixedMessage = createMockMixedMessage(CHAT_TEXT, key, MY_CODE);
 
         Page<ChatMessage> mockPage = new PageImpl<>(
             List.of(mixedMessage),
@@ -375,12 +339,50 @@ class ChatMessageServiceTest {
         return chatRoom;
     }
 
-    private ChatMessage createMockMessage(String text, String senderCode) {
+    private ChatMessage createMockTextMessage(String text, String senderCode) {
         ChatMessage message = ChatMessage.builder()
             .roomId(ROOM_ID)
             .senderCode(senderCode)
             .type(MessageType.TEXT)
             .text(text)
+            .build();
+
+        ReflectionTestUtils.setField(message, "id", "msg-" + Instant.now().getNano());
+        ReflectionTestUtils.setField(message, "sentAt", Instant.now());
+
+        return message;
+    }
+
+    private ChatMessage createMockFileMessage(String key, String senderCode) {
+        ChatMessage message = ChatMessage.builder()
+            .roomId(ROOM_ID)
+            .senderCode(senderCode)
+            .type(MessageType.FILE)
+            .text(null)
+            .file(
+                File.builder()
+                    .key(key)
+                    .build()
+            )
+            .build();
+
+        ReflectionTestUtils.setField(message, "id", "msg-" + Instant.now().getNano());
+        ReflectionTestUtils.setField(message, "sentAt", Instant.now());
+
+        return message;
+    }
+
+    private ChatMessage createMockMixedMessage(String text, String key, String senderCode) {
+        ChatMessage message = ChatMessage.builder()
+            .roomId(ROOM_ID)
+            .senderCode(senderCode)
+            .type(MessageType.MIXED)
+            .text(text)
+            .file(
+                File.builder()
+                    .key(key)
+                    .build()
+            )
             .build();
 
         ReflectionTestUtils.setField(message, "id", "msg-" + Instant.now().getNano());

--- a/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
+++ b/communication-service/src/test/java/com/example/communicationservice/service/ChatMessageServiceTest.java
@@ -1,5 +1,9 @@
 package com.example.communicationservice.service;
 
+import com.example.communicationservice.client.S3ServiceClient;
+import com.example.communicationservice.client.dto.input.FileDownloadUrlGenerateInput;
+import com.example.communicationservice.client.dto.output.FileDownloadUrlGenerateOutput;
+import com.example.communicationservice.client.dto.output.FileDownloadUrlListGenerateOutput;
 import com.example.communicationservice.common.exception.ChatRoomException;
 import com.example.communicationservice.common.status.ResponseDtoStatus;
 import com.example.communicationservice.controller.dto.request.ChatMessageSendRequest;
@@ -7,9 +11,12 @@ import com.example.communicationservice.controller.dto.response.ChatMessageListR
 import com.example.communicationservice.controller.dto.response.ChatMessageSendResponse;
 import com.example.communicationservice.entity.ChatMessage;
 import com.example.communicationservice.entity.ChatRoom;
+import com.example.communicationservice.entity.File;
 import com.example.communicationservice.repository.ChatMessageRepository;
 import com.example.communicationservice.repository.ChatRoomRepository;
 import com.example.communicationservice.type.MessageType;
+import org.hexagon.core.dto.ResponseDto;
+import org.hexagon.core.vo.FileType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -50,6 +57,9 @@ class ChatMessageServiceTest {
 
     @Mock
     private ChatMessageRepository chatMessageRepository;
+
+    @Mock
+    private S3ServiceClient s3ServiceClient;
 
     @Test
     void 채팅방_메시지_목록을_페이징하여_조회한다() {
@@ -212,6 +222,146 @@ class ChatMessageServiceTest {
 
         verify(chatMessageRepository, times(0)).save(any());
         verify(chatRoomRepository, times(0)).save(any(ChatRoom.class));
+    }
+
+    @Test
+    void TEXT_타입_메시지를_조회하는_경우_파일_다운로드_URL을_발급받지_않는다() {
+        // given
+        ChatRoom chatRoom = createMockChatRoom(List.of(MY_CODE, PARTNER_CODE));
+        Pageable pageable = PageRequest.of(0, 10);
+
+        ChatMessage textMessage = createMockMessage("텍스트 메시지", MY_CODE);
+
+        Page<ChatMessage> mockPage = new PageImpl<>(
+            List.of(textMessage),
+            pageable,
+            1
+        );
+
+        given(chatRoomRepository.findById(eq(ROOM_ID)))
+            .willReturn(Optional.of(chatRoom));
+        given(chatMessageRepository.findAllByRoomId(eq(ROOM_ID), eq(pageable)))
+            .willReturn(mockPage);
+
+        // when
+        ChatMessageListReadResponse response =
+            chatMessageService.findMessagesByRoomId(ROOM_ID, MY_CODE, pageable);
+
+        // then
+        assertThat(response.messages()).hasSize(1);
+        assertThat(response.messages().get(0).file()).isNull();
+
+        verify(s3ServiceClient, times(0)).generateDownloadUrl(any());
+    }
+
+    @Test
+    void FILE_타입_메시지를_조회하는_경우_파일_다운로드_URL을_발급받는다() {
+        // given
+        String key = "file-key-1";
+        String queryString = "?query=string";
+        ChatRoom chatRoom = createMockChatRoom(List.of(MY_CODE, PARTNER_CODE));
+        Pageable pageable = PageRequest.of(0, 10);
+
+        File file = File.builder()
+            .key(key)
+            .build();
+
+        ChatMessage fileMessage = ChatMessage.builder()
+            .roomId(ROOM_ID)
+            .senderCode(MY_CODE)
+            .type(MessageType.FILE)
+            .file(file)
+            .build();
+
+        ReflectionTestUtils.setField(fileMessage, "id", "file-msg-1");
+        ReflectionTestUtils.setField(fileMessage, "sentAt", Instant.now());
+
+        Page<ChatMessage> mockPage = new PageImpl<>(
+            List.of(fileMessage),
+            pageable,
+            1
+        );
+
+        FileDownloadUrlGenerateOutput urlOutput =
+            new FileDownloadUrlGenerateOutput(key, queryString, FileType.IMAGE);
+
+        FileDownloadUrlListGenerateOutput listOutput =
+            new FileDownloadUrlListGenerateOutput(List.of(urlOutput));
+
+        given(chatRoomRepository.findById(eq(ROOM_ID)))
+            .willReturn(Optional.of(chatRoom));
+        given(chatMessageRepository.findAllByRoomId(eq(ROOM_ID), eq(pageable)))
+            .willReturn(mockPage);
+        given(s3ServiceClient.generateDownloadUrl(any()))
+            .willReturn(ResponseDto.success(listOutput));
+
+        // when
+        ChatMessageListReadResponse response =
+            chatMessageService.findMessagesByRoomId(ROOM_ID, MY_CODE, pageable);
+
+        // then
+        assertThat(response.messages()).hasSize(1);
+        assertThat(response.messages().get(0).file()).isNotNull();
+        assertThat(response.messages().get(0).file().key()).isEqualTo(key);
+        assertThat(response.messages().get(0).file().queryString()).isEqualTo(queryString);
+
+        verify(s3ServiceClient, times(1))
+            .generateDownloadUrl(any(FileDownloadUrlGenerateInput.class));
+    }
+
+    @Test
+    void MIXED_타입_메시지를_조회하는_경우_파일_다운로드_URL을_발급받는다() {
+        // given
+        String key = "file-key-1";
+        String queryString = "?query=string";
+        ChatRoom chatRoom = createMockChatRoom(List.of(MY_CODE, PARTNER_CODE));
+        Pageable pageable = PageRequest.of(0, 10);
+
+        File file = File.builder()
+            .key(key)
+            .build();
+
+        ChatMessage mixedMessage = ChatMessage.builder()
+            .roomId(ROOM_ID)
+            .senderCode(PARTNER_CODE)
+            .type(MessageType.MIXED)
+            .text(CHAT_TEXT)
+            .file(file)
+            .build();
+
+        ReflectionTestUtils.setField(mixedMessage, "id", "mixed-msg-1");
+        ReflectionTestUtils.setField(mixedMessage, "sentAt", Instant.now());
+
+        Page<ChatMessage> mockPage = new PageImpl<>(
+            List.of(mixedMessage),
+            pageable,
+            1
+        );
+
+        FileDownloadUrlGenerateOutput urlOutput =
+            new FileDownloadUrlGenerateOutput(key, queryString, FileType.IMAGE);
+
+        FileDownloadUrlListGenerateOutput listOutput =
+            new FileDownloadUrlListGenerateOutput(List.of(urlOutput));
+
+        given(chatRoomRepository.findById(eq(ROOM_ID)))
+            .willReturn(Optional.of(chatRoom));
+        given(chatMessageRepository.findAllByRoomId(eq(ROOM_ID), eq(pageable)))
+            .willReturn(mockPage);
+        given(s3ServiceClient.generateDownloadUrl(any()))
+            .willReturn(ResponseDto.success(listOutput));
+
+        // when
+        ChatMessageListReadResponse response =
+            chatMessageService.findMessagesByRoomId(ROOM_ID, MY_CODE, pageable);
+
+        // then
+        assertThat(response.messages()).hasSize(1);
+        assertThat(response.messages().get(0).file().key()).isEqualTo(key);
+        assertThat(response.messages().get(0).file().queryString()).isEqualTo(queryString);
+
+        verify(s3ServiceClient, times(1))
+            .generateDownloadUrl(any());
     }
 
     private ChatRoom createMockChatRoom(List<String> memberCodes) {


### PR DESCRIPTION
## 🐛 관련 이슈
 <!-- Closes #{이슈-번호} 형태로 작성하세요 (ex: Closes #134) -->
Closes #195 

## 📌 목적
채팅방에서 파일 메시지를 조회하는 기능을 구현합니다.

## ✅ 변경 사항

채팅방에서 채팅 메시지를 조회할 때, 파일이 포함된 메시지가 존재할 수 있습니다.

이 경우에는 해당 파일의 `pre-signed download URL`을 조회 응답에 포함해야 합니다.

이를 위해 채팅 메시지 조회 흐름에서 다음과 같은 단계로 로직을 구성했습니다.

<br>

### 1️⃣ 파일 key 리스트 추출

조회한 메시지 리스트를 순회하며 파일이 포함된 메시지에서 파일 key를 추출해 리스트에 저장합니다.

```java
    /**
     * 채팅 메시지 목록에서 파일이 포함된 메시지의 파일 key를 추출합니다.
     * @param messages 채팅 메시지 목록
     * @return 파일이 포함된 메시지에서 추출한 파일 key 목록
     */
    private List<String> extractFileKeys(List<ChatMessage> messages) {
        return messages.stream()
            .filter(message -> hasFile(message.getType())) // 파일이 포함된 메시지만 필터링
            .map(ChatMessage::getFile)
            .filter(Objects::nonNull)
            .map(File::getKey) // key 추출
            .distinct() // 동일 파일 중복 방지
            .toList();
    }
```

<br>

### 2️⃣ pre-signed download URL 발급

추출한 파일 key 리스트를 기준으로 S3 Service에 pre-signed download URL 발급을 요청합니다.

그 다음 { `파일 key` -> `pre-signed download URL 생성 응답` } 형태의 Map으로 변환합니다.

이때 Map을 사용한 이유는 메시지마다 타입, 즉 파일 포함 여부가 다를 수 있는 상황에서 메시지와 URL을 유연하게 매핑할 수 있다고 생각했기 때문입니다.

```java
/**
     * S3 service와 통신해 다중 파일에 대한 pre-signed download URL 매핑 정보를 생성합니다.
     * @param keys pre-signed download URL을 생성할 파일 key 목록
     * @return 파일 key 기반 pre-signed download URL 매핑 정보
     */
    private Map<String, FileDownloadUrlGenerateOutput> generateDownloadUrlMap(List<String> keys) {
        if (keys.isEmpty()) {
            return Map.of();
        }

        // feign client 요청 dto 생성
        FileDownloadUrlGenerateInput input = new FileDownloadUrlGenerateInput(keys);

        // S3 service에 pre-signed download URL 발급 요청
        FileDownloadUrlListGenerateOutput output = s3ServiceClient.generateDownloadUrl(input).data();

        // 파일 key에 pre-signed download URL 생성 응답 매핑
        return output.urls().stream()
            .collect(
                Collectors.toMap(
                    FileDownloadUrlGenerateOutput::key, // key
                    Function.identity() // value // 입력으로 받은 FileDownloadUrlGenerateOutput을 그대로 반환
                )
            );
    }
```

<br>

### 3️⃣ 채팅 메시지 조회 응답 생성

- 조회한 메시지 리스트를 순회하며 엔티티를 DTO로 변환합니다.

    - 파일이 포함된 메시지의 경우, `ChatMapper.toReadResponse`에서 전달받은 Map을 사용해 해당 메시지에 맞는 pre-signed download URL을 응답에 조합합니다.

- 페이징 정보를 포함해 최종 응답을 생성합니다.

```java
        List<ChatMessageReadResponse> messages = messagePage.getContent().stream()
            .map(message → ChatMapper.toReadResponse(message, keyToDownloadUrl))
            .toList();

        PageInfo pageInfo = PageMapper.toPageInfo(messagePage);

        return new ChatMessageListReadResponse(messages, pageInfo);

```

## 🧪 테스트 방법
신규 서비스 단위 테스트 코드를 작성했습니다.

- TEXT 타입 메시지 조회 시 파일 다운로드 URL 미발급을 검증합니다.

- FILE 타입 메시지 조회 시 파일 다운로드 URL 발급을 검증합니다.

- MIXED 타입 메시지 조회 시 파일 다운로드 URL 발급을 검증합니다.


## 📎 참고 사항
- 선행 브랜치(feat/chat/175)가 아직 병합되지 않은 관계로 PR base 브랜치가 선행 브랜치로 설정되어 있습니다.

- 선행 브랜치 병합 이후 PR base 브랜치를 develop으로 변경하겠습니다.

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [x] 이슈 번호를 입력 했나요?
- [x] 코드 컨벤션을 모두 지켰나요?
- [x] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
