### PR TITLE
bug(contract): API 호출에 따른 일부 수정 및 특정 의뢰글 지원 프리랜서 코드를 반환하는 내부 API 추가

### DIFF
--- a/contract-service/src/main/java/com/example/contractservice/common/config/FeignClientConfig.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/config/FeignClientConfig.java
@@ -1,11 +1,21 @@
 package com.example.contractservice.common.config;
 
 import com.example.contractservice.ContractServiceApplication;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableFeignClients(basePackageClasses = ContractServiceApplication.class)
 public class FeignClientConfig {
 
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer feignEnumCustomizer() {
+        return builder ->
+                builder.featuresToEnable(
+                        DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE
+                );
+    }
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/ContractInternalController.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/ContractInternalController.java
@@ -10,6 +10,7 @@ import com.example.contractservice.contract.controller.dto.response.CommissionCa
 import com.example.contractservice.contract.controller.dto.response.ContractBriefWithNicknameResponse;
 import com.example.contractservice.contract.controller.dto.response.ContractPayResponse;
 import com.example.contractservice.contract.service.CommissionsCapacityService;
+import com.example.contractservice.contract.service.ContractReadService;
 import com.example.contractservice.contract.service.ContractService;
 import com.example.contractservice.contract.service.dto.request.ContractPayServiceRequest;
 import jakarta.validation.Valid;
@@ -34,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ContractInternalController {
     private final ContractService contractService;
     private final CommissionsCapacityService commissionsCapacityService;
+    private final ContractReadService contractReadService;
 
     @ContractPayApi
     @PostMapping("/pay")
@@ -56,6 +58,12 @@ public class ContractInternalController {
     @ResponseStatus(HttpStatus.OK)
     public ResponseDto<MemberRoleStatusResponse> getMemberRoleStatus(@PathVariable("member-code") String memberCode) {
         return ResponseDto.success(contractService.getMemberRoleStatus(memberCode));
+    }
+
+    @GetMapping("/commissions/{commission-code}/freelancer")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseDto<List<String>> getAppliedFreelancerCodes(@PathVariable("commission-code") String commissionCode) {
+        return ResponseDto.success(contractReadService.getAppliedFreelancerCodesBy(commissionCode));
     }
 
     @CommissionCapacityUpsertApi

--- a/contract-service/src/main/java/com/example/contractservice/contract/repository/ContractJpaRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/repository/ContractJpaRepository.java
@@ -16,4 +16,11 @@ public interface ContractJpaRepository extends JpaRepository<ContractEntity, Lon
         WHERE c.code IN :codes
     """)
     List<ContractEntity> findAllByCodes(List<String> codes);
+
+    @Query(value = """
+        SELECT freelancer_code
+        FROM contracts
+        WHERE status = :status AND commission_code = :commissionCode
+    """, nativeQuery = true)
+    List<String> findFreelancerBy(String commissionCode, String status);
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/repository/ContractRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/repository/ContractRepository.java
@@ -93,6 +93,10 @@ public class ContractRepository {
                 .toList();
     }
 
+    public List<String> findAppliedFreelancerCodesBy(String commissionCode) {
+        return contractJpaRepository.findFreelancerBy(commissionCode, REQUESTED.name());
+    }
+
     private List<ContractEntity> fetch(QContractEntity qContractEntity, BooleanExpression predicate, OrderSpecifier<?>[] orderSpecifiers, int limit) {
         return queryFactory
                 .selectFrom(qContractEntity)
@@ -131,6 +135,14 @@ public class ContractRepository {
         };
     }
 
+    public boolean existsClientContractBy(String memberCode) {
+        return findFirstContract(memberCode, this::getClientWhereClause) != null;
+    }
+
+    public boolean existsFreelancerContractBy(String memberCode) {
+        return findFirstContract(memberCode, this::getFreelancerWhereClause) != null;
+    }
+
     private OrderSpecifier<?>[] getOrderSpec(QContractEntity qContractEntity, Order order) {
         List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
 
@@ -142,14 +154,6 @@ public class ContractRepository {
         orderSpecifiers.add(qContractEntity.code.asc());
 
         return orderSpecifiers.toArray(OrderSpecifier<?>[]::new);
-    }
-
-    public boolean existsClientContractBy(String memberCode) {
-        return findFirstContract(memberCode, this::getClientWhereClause) != null;
-    }
-
-    public boolean existsFreelancerContractBy(String memberCode) {
-        return findFirstContract(memberCode, this::getFreelancerWhereClause) != null;
     }
 
     private ContractEntity findFirstContract(String memberCode, BiFunction<QContractEntity, String, Predicate> whereClause) {
@@ -167,5 +171,4 @@ public class ContractRepository {
     private Predicate getFreelancerWhereClause(QContractEntity qContractEntity, String memberCode) {
         return qContractEntity.freelancerCode.eq(memberCode).and(qContractEntity.status.in(REQUESTED, PAID, IN_PROGRESS));
     }
-
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/ContractReadService.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/ContractReadService.java
@@ -55,6 +55,10 @@ public class ContractReadService {
         return ContractDetailResponse.of(contract, clientName, freelancerCode);
     }
 
+    public List<String> getAppliedFreelancerCodesBy(String commissionCode) {
+        return contractRepository.findAppliedFreelancerCodesBy(commissionCode);
+    }
+
     private void validateMember(String memberCode, Contract contract) {
         ContractInfo contractInfo = contract.getInfo();
 

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/ContractService.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/ContractService.java
@@ -18,11 +18,10 @@ import com.example.contractservice.contract.service.dto.request.ContractPayServi
 import com.example.contractservice.contract.service.dto.response.MemberInfoResponse;
 import com.example.contractservice.contract.service.dto.response.MemberInfoResponse.MemberInfo;
 import com.example.contractservice.contract.controller.dto.response.MemberRoleStatusResponse;
-import java.net.URI;
+import com.example.contractservice.contract.service.dto.response.MemberInfoResponse.MemberRole;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -152,7 +151,7 @@ public class ContractService {
                 .filter(memberInfo -> memberInfo.memberCode().equals(freelancerCode))
                 .findAny().orElseThrow(() -> new ContractException(INVALID_MEMBER));
 
-        if (!freelancerInfo.canWork()) {
+        if (freelancerInfo.memberRole() != MemberRole.FREELANCER) {
             throw new ContractException(NOT_FREELANCER);
         }
     }

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/ContractService.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/ContractService.java
@@ -27,6 +27,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hexagon.core.events.contract.ContractEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +43,7 @@ public class ContractService {
     private final ContractRepository contractRepository;
     private final ContractPayService contractPayService;
     private final ContractCancelService contractCancelService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public List<ContractBriefWithNicknameResponse> getBriefInfos(List<String> codes) {
         // 코드를 기반으로 모든 Contract를 한 번에 조회
@@ -74,6 +77,8 @@ public class ContractService {
         Contract createdContract = request.toContract();
 
         Contract contract = contractRepository.saveContract(createdContract);
+
+        applicationEventPublisher.publishEvent(new ContractEvent(contract.getCode(), contract.getInfo().commissionCode(), contract.getCreatedAt(), contract.getInfo().status().name()));
 
         return ContractCreateResponse.of(contract.getCode());
     }

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/ContractService.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/ContractService.java
@@ -156,7 +156,7 @@ public class ContractService {
                 .filter(memberInfo -> memberInfo.memberCode().equals(freelancerCode))
                 .findAny().orElseThrow(() -> new ContractException(INVALID_MEMBER));
 
-        if (freelancerInfo.memberRole() != MemberRole.FREELANCER) {
+        if (freelancerInfo.role() != MemberRole.FREELANCER) {
             throw new ContractException(NOT_FREELANCER);
         }
     }

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/dto/response/MemberInfoResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/dto/response/MemberInfoResponse.java
@@ -1,5 +1,6 @@
 package com.example.contractservice.contract.service.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import java.util.List;
 
 public record MemberInfoResponse(
@@ -9,11 +10,14 @@ public record MemberInfoResponse(
     public record MemberInfo (
             String memberCode,
             String nickName,
-            MemberRole memberRole
+            MemberRole role
     ) {}
 
     public enum MemberRole {
         CLIENT,
-        FREELANCER
+        FREELANCER,
+
+        @JsonEnumDefaultValue
+        ETC
     }
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/dto/response/MemberInfoResponse.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/dto/response/MemberInfoResponse.java
@@ -9,6 +9,11 @@ public record MemberInfoResponse(
     public record MemberInfo (
             String memberCode,
             String nickName,
-            Boolean canWork
+            MemberRole memberRole
     ) {}
+
+    public enum MemberRole {
+        CLIENT,
+        FREELANCER
+    }
 }

--- a/contract-service/src/test/java/com/example/contractservice/contract/common/ContractPaySettlementTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/contract/common/ContractPaySettlementTest.java
@@ -84,7 +84,7 @@ class ContractPaySettlementTest {
 
     @Test
     @DisplayName("정산으로 인한 예치금 입금, 결제로 인한 예치금 출금이 동시에 발생할 수 있다.")
-    void processPayment() throws Exception{
+    void success_process_payment_and_settlement_at_the_same_time() throws Exception{
         // given
         AtomicInteger paySuccessCount = new AtomicInteger(0);
         AtomicInteger settlementSuccessCount = new AtomicInteger(0);
@@ -92,7 +92,7 @@ class ContractPaySettlementTest {
         long paymentAmount = 1111L;
         long initAmount = 500_000L;
         long settlementOriginalAmount = 10000;
-        String userCode = "userCode";
+        String userCode = UUID.randomUUID().toString();
         DepositEntity userDeposit = DepositEntity.createBy(userCode);
         userDeposit.updateInfo(initAmount);
         DepositEntity adminDeposit = DepositEntity.createBy(adminMemberCode);

--- a/contract-service/src/test/java/com/example/contractservice/contract/service/ContractInternalServiceTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/contract/service/ContractInternalServiceTest.java
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @Import(TestConfig.class)
@@ -25,6 +28,11 @@ class ContractInternalServiceTest {
     ContractService contractService;
     @Autowired
     private ContractJpaRepository contractJpaRepository;
+
+    @MockitoBean
+    KafkaTemplate<String, String> kafkaTemplate;
+    @MockitoBean
+    KafkaAdmin kafkaAdmin;
 
     @AfterEach
     void tearDown() {

--- a/contract-service/src/test/java/com/example/contractservice/contract/service/ContractReadServiceTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/contract/service/ContractReadServiceTest.java
@@ -19,6 +19,7 @@ import com.example.contractservice.contract.service.dto.request.ContractDetailRe
 import com.example.contractservice.contract.service.dto.request.ContractReadCursorRequest;
 import com.example.contractservice.contract.service.dto.response.MemberInfoResponse;
 import com.example.contractservice.contract.service.dto.response.MemberInfoResponse.MemberInfo;
+import com.example.contractservice.contract.service.dto.response.MemberInfoResponse.MemberRole;
 import java.time.Instant;
 import java.util.List;
 import java.util.Random;
@@ -140,8 +141,8 @@ class ContractReadServiceTest {
 
         when(restTemplate.getForObject(any(), eq(MemberInfoResponse.class)))
                 .thenReturn(new MemberInfoResponse(List.of(
-                        new MemberInfo(memberCode, "멤버 닉네임", true),
-                        new MemberInfo(opponentCode, "상대방 닉네임", false)))
+                        new MemberInfo(memberCode, "멤버 닉네임", MemberRole.FREELANCER),
+                        new MemberInfo(opponentCode, "상대방 닉네임", MemberRole.CLIENT)))
                 );
 
         // when

--- a/contract-service/src/test/java/com/example/contractservice/contract/service/ContractReadServiceTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/contract/service/ContractReadServiceTest.java
@@ -4,10 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import org.hexagon.core.dto.ResponseDto;
 import com.example.contractservice.common.TestConfig;
+import com.example.contractservice.common.util.feign.MemberClient;
 import com.example.contractservice.contract.common.ContractStatus;
 import com.example.contractservice.contract.common.Order;
 import com.example.contractservice.contract.controller.dto.response.ContractBriefResponse;
@@ -31,12 +32,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.web.client.RestTemplate;
 
 @SpringBootTest
 @Import(TestConfig.class)
@@ -48,8 +47,8 @@ class ContractReadServiceTest {
     @Autowired
     private ContractReadService contractReadService;
 
-    @MockBean
-    RestTemplate restTemplate;
+    @MockitoBean
+    MemberClient memberClient;
 
     @MockitoBean
     KafkaTemplate<String, String> kafkaTemplate;
@@ -139,10 +138,10 @@ class ContractReadServiceTest {
 
         ContractEntity saved = contractJpaRepository.save(entity);
 
-        when(restTemplate.getForObject(any(), eq(MemberInfoResponse.class)))
-                .thenReturn(new MemberInfoResponse(List.of(
+        when(memberClient.getMemberInfo(any()))
+                .thenReturn(ResponseDto.success(new MemberInfoResponse(List.of(
                         new MemberInfo(memberCode, "멤버 닉네임", MemberRole.FREELANCER),
-                        new MemberInfo(opponentCode, "상대방 닉네임", MemberRole.CLIENT)))
+                        new MemberInfo(opponentCode, "상대방 닉네임", MemberRole.CLIENT))))
                 );
 
         // when


### PR DESCRIPTION
# 내부 API 추가는 bug가 아니긴 한데 빠른 적용을 위해 이 PR에 함께 올립니다!!

## 🐛 관련 이슈
 <!-- Closes #{이슈-번호} 형태로 작성하세요 (ex: Closes #134) -->
Closes #207 

## 📌 목적

넘겨주는 인자가 Role로 변경됨에 따라 바꿔주었습니다.
REQUESTED 계약 생성 시, 장바구니에 넣어주기 위해 이벤트 추가 필요
특정 의뢰글에 지원한 프리랜서 코드를 알기 위한 API 추가가 필요

## ✅ 변경 사항
### 멤버 모듈로부터 받는 값을 `canWork` -> `memberRole`로 받도록 수정
`MemberRole`은 enum으로 관리됩니다. 이는 단순 String 하드코딩보다 확장성이 좋을 것으로 기대됩니다. (역할 별 특정 기능이 추가된다든지 등)

추가적으로 일부 테스트 코드를 조금 수정했습니다.

### 계약이 생성될 경우, contract-topic에 이벤트 발행
status는 `REQUESTED`입니다!

### 특정 의뢰글 지원 프리랜서 코드를 반환하는 내부 API 추가
URL은 `/internal/contracts/commissions/{commission-code}/freelancer` 입니다. `ResponseDto<List<String>>` 타입으로 반환됩니다.

## 🧪 테스트 방법
따로 없음

## 📎 참고 사항
- 관련 이슈 번호 : #207 

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [ ] 이슈 번호를 입력 했나요?
- [ ] 코드 컨벤션을 모두 지켰나요?
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
