### PR TITLE
feat(contract): 의뢰글 지원 동시성 제어 구현

### DIFF
--- a/contract-service/src/main/java/com/example/contractservice/contract/domain/exception/ContractErrorCode.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/domain/exception/ContractErrorCode.java
@@ -17,7 +17,8 @@ public class ContractErrorCode extends DomainErrorCode {
     public static final ContractErrorCode INVALID_MEMBER_COUNT;
 
     public static final ContractErrorCode COMMISSION_CAPACITY_NOT_FOUND;
-    public static final ContractErrorCode COMMISSION_RECRUIT_FULL;
+    public static final ContractErrorCode COMMISSION_SELECTION_COUNT_FULL;
+    public static final ContractErrorCode COMMISSION_APPLIED_COUNT_FULL;
 
     public static final ContractErrorCode CANCEL_NOT_AVAILABLE;
     public static final ContractErrorCode COMMISSION_NOT_AVAILABLE;
@@ -35,8 +36,9 @@ public class ContractErrorCode extends DomainErrorCode {
 
         INVALID_MEMBER_COUNT = new ContractErrorCode(HttpStatus.BAD_REQUEST, 4030, "계약 참여자 수를 만족하지 않습니다.");
 
-        COMMISSION_CAPACITY_NOT_FOUND = new ContractErrorCode(HttpStatus.NOT_FOUND, 4040, "해당 의뢰글의 모집 인원, 선정 인원 정보가 존재하지 않습니다.");
-        COMMISSION_RECRUIT_FULL = new ContractErrorCode(HttpStatus.CONFLICT, 4041, "해당 의뢰글에 대한 모집 인원이 꽉 찼습니다.");
+        COMMISSION_CAPACITY_NOT_FOUND = new ContractErrorCode(HttpStatus.NOT_FOUND, 4040, "해당 의뢰글의 지원 인원, 선정 인원 정보가 존재하지 않습니다.");
+        COMMISSION_SELECTION_COUNT_FULL = new ContractErrorCode(HttpStatus.CONFLICT, 4041, "해당 의뢰글에 대한 선정 인원이 꽉 찼습니다.");
+        COMMISSION_APPLIED_COUNT_FULL = new ContractErrorCode(HttpStatus.CONFLICT, 4042, "해당 의뢰글의 지원 가능 인원 수가 꽉 찼습니다.");
 
         CANCEL_NOT_AVAILABLE = new ContractErrorCode(HttpStatus.BAD_REQUEST, 4050, "취소할 수 있는 계약의 상태가 아닙니다.");
         COMMISSION_NOT_AVAILABLE = new ContractErrorCode(HttpStatus.BAD_REQUEST, 4051, "관련 의뢰글이 존재하지 않거나 마감되었습니다.");

--- a/contract-service/src/main/java/com/example/contractservice/contract/repository/CommissionsCapacityJpaRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/repository/CommissionsCapacityJpaRepository.java
@@ -3,7 +3,17 @@ package com.example.contractservice.contract.repository;
 import com.example.contractservice.contract.entity.CommissionsCapacity;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommissionsCapacityJpaRepository extends JpaRepository<CommissionsCapacity, Long> {
     Optional<CommissionsCapacity> findByCommissionCode(String commissionCode);
+
+    @Modifying
+    @Query(value = """
+        UPDATE commissions_capacity
+        SET applied_count = applied_count + 1
+        WHERE commission_code = :commissionCode AND apply_capacity > applied_count
+    """, nativeQuery = true)
+    int increaseAppliedCount(String commissionCode);
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/repository/CommissionsCapacityRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/repository/CommissionsCapacityRepository.java
@@ -4,7 +4,9 @@ import com.example.contractservice.contract.domain.exception.ContractException;
 import com.example.contractservice.contract.entity.CommissionsCapacity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
+import static com.example.contractservice.contract.domain.exception.ContractErrorCode.COMMISSION_APPLIED_COUNT_FULL;
 import static  com.example.contractservice.contract.domain.exception.ContractErrorCode.COMMISSION_CAPACITY_NOT_FOUND;
 
 @Repository
@@ -28,5 +30,14 @@ public class CommissionsCapacityRepository {
 
     public void saveCapacity(CommissionsCapacity capacity) {
         commissionsCapacityJpaRepository.save(capacity);
+    }
+
+    @Transactional
+    public void increaseAppliedCount(String commissionCode) {
+        int updatedCount = commissionsCapacityJpaRepository.increaseAppliedCount(commissionCode);
+
+        if (updatedCount <= 0) {
+            throw new ContractException(COMMISSION_APPLIED_COUNT_FULL);
+        }
     }
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/ContractPayService.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/ContractPayService.java
@@ -1,6 +1,6 @@
 package com.example.contractservice.contract.service;
 
-import static com.example.contractservice.contract.domain.exception.ContractErrorCode.COMMISSION_RECRUIT_FULL;
+import static com.example.contractservice.contract.domain.exception.ContractErrorCode.COMMISSION_SELECTION_COUNT_FULL;
 import static com.example.contractservice.contract.domain.exception.ContractErrorCode.INVALID_PAYMENT_MEMBER;
 import static com.example.contractservice.contract.domain.exception.ContractErrorCode.NOT_REQUESTED_STATUS;
 
@@ -92,7 +92,7 @@ public class ContractPayService {
                 contract.getInfo().commissionCode());
 
         if (capacity.getSelectionCapacity() <= capacity.getSelectedCount()) {
-            throw new ContractException(COMMISSION_RECRUIT_FULL);
+            throw new ContractException(COMMISSION_SELECTION_COUNT_FULL);
         }
 
         capacity.increaseSelectedCount();

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/ContractService.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/ContractService.java
@@ -12,17 +12,16 @@ import com.example.contractservice.contract.controller.dto.response.ContractCrea
 import com.example.contractservice.contract.controller.dto.response.ContractPayResponse;
 import com.example.contractservice.contract.domain.Contract;
 import com.example.contractservice.contract.domain.exception.ContractException;
+import com.example.contractservice.contract.repository.CommissionsCapacityRepository;
 import com.example.contractservice.contract.repository.ContractRepository;
 import com.example.contractservice.contract.service.dto.request.ContractPayProcessRequest;
 import com.example.contractservice.contract.service.dto.request.ContractPayServiceRequest;
 import com.example.contractservice.contract.service.dto.response.MemberInfoResponse;
 import com.example.contractservice.contract.service.dto.response.MemberInfoResponse.MemberInfo;
 import com.example.contractservice.contract.controller.dto.response.MemberRoleStatusResponse;
-import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -42,6 +41,7 @@ public class ContractService {
     private final ContractRepository contractRepository;
     private final ContractPayService contractPayService;
     private final ContractCancelService contractCancelService;
+    private final CommissionsCapacityRepository commissionsCapacityRepository;
 
     public List<ContractBriefWithNicknameResponse> getBriefInfos(List<String> codes) {
         // 코드를 기반으로 모든 Contract를 한 번에 조회
@@ -69,6 +69,8 @@ public class ContractService {
 
     @Transactional
     public ContractCreateResponse requestContract(ContractCreateRequest request) {
+        commissionsCapacityRepository.increaseAppliedCount(request.commissionCode());
+
         isValidMember(request.clientCode(), request.freelancerCode());
         isCommissionOpen(request.commissionCode());
 

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/mapper/ContractMapper.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/mapper/ContractMapper.java
@@ -17,6 +17,7 @@ public abstract class ContractMapper {
                 .code(contract.getCode())
                 .clientCode(contractInfo.clientCode())
                 .freelancerCode(contractInfo.freelancerCode())
+                .commissionCode(contractInfo.commissionCode())
                 .status(contractInfo.status())
                 .startedAt(contractInfo.startedAt())
                 .endedAt(contractInfo.endedAt())

--- a/contract-service/src/test/java/com/example/contractservice/contract/service/ContractServiceTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/contract/service/ContractServiceTest.java
@@ -1,10 +1,17 @@
 package com.example.contractservice.contract.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.example.contractservice.common.TestConfig;
+import com.example.contractservice.common.util.feign.CommissionClient;
+import com.example.contractservice.common.util.feign.MemberClient;
 import com.example.contractservice.contract.common.ContractStatus;
 import com.example.contractservice.contract.controller.dto.request.ContractCancelRequest;
+import com.example.contractservice.contract.controller.dto.request.ContractCreateRequest;
 import com.example.contractservice.contract.controller.dto.response.ContractPayResponse;
 import com.example.contractservice.contract.domain.Contract;
 import com.example.contractservice.contract.entity.CommissionsCapacity;
@@ -12,6 +19,9 @@ import com.example.contractservice.contract.entity.ContractEntity;
 import com.example.contractservice.contract.repository.CommissionsCapacityJpaRepository;
 import com.example.contractservice.contract.repository.ContractJpaRepository;
 import com.example.contractservice.contract.service.dto.request.ContractPayServiceRequest;
+import com.example.contractservice.contract.service.dto.response.CommissionRecruitmentResponse;
+import com.example.contractservice.contract.service.dto.response.MemberInfoResponse;
+import com.example.contractservice.contract.service.dto.response.MemberInfoResponse.MemberInfo;
 import com.example.contractservice.contract.service.mapper.ContractMapper;
 import com.example.contractservice.deposit.entity.DepositEntity;
 import com.example.contractservice.deposit.repository.DepositHistoryJpaRepository;
@@ -23,7 +33,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.IntStream;
+import org.hexagon.core.dto.ResponseDto;
 import org.hexagon.core.vo.PaymentType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +47,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
 import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -50,10 +65,15 @@ class ContractServiceTest {
     ContractService contractService;
     @Autowired
     CommissionsCapacityJpaRepository commissionsCapacityJpaRepository;
+
     @MockitoBean
     KafkaTemplate<String, String> kafkaTemplate;
     @MockitoBean
     KafkaAdmin kafkaAdmin;
+    @MockitoBean
+    MemberClient memberClient;
+    @MockitoBean
+    CommissionClient commissionClient;
 
     @Value("${admin.member.code}")
     String adminMemberCode;
@@ -71,6 +91,7 @@ class ContractServiceTest {
         depositJpaRepository.deleteAllInBatch();
         settlementJpaRepository.deleteAllInBatch();
         depositHistoryJpaRepository.deleteAllInBatch();
+        commissionsCapacityJpaRepository.deleteAllInBatch();
     }
 
     @Test
@@ -188,5 +209,64 @@ class ContractServiceTest {
         assertEquals(0L, adminDeposit.getAmount());
         assertEquals(unitAmount * contractsNum, clientDeposit.getAmount());
         assertEquals(0, allSettlements.size());
+    }
+
+    @Test
+    @DisplayName("의뢰글에 동시 지원 요청이 들어와도 지원 인원 이상으로 요청이 수행될 수 없다")
+    void success_blocking_over_request_on_full_commission() throws Exception {
+        // given
+        String clientCode = UUID.randomUUID().toString();
+        String freelancerCode = UUID.randomUUID().toString();
+        String commissionCode = UUID.randomUUID().toString();
+
+        int applyCapacity = 5; // 최대 지원 인원
+        int selectionCapacity = 3;
+
+        commissionsCapacityJpaRepository.save(
+                CommissionsCapacity.createBy(commissionCode, applyCapacity, selectionCapacity));
+
+        int tryCount = applyCapacity * 2;
+        ExecutorService threadPool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+        CountDownLatch countDownLatch = new CountDownLatch(tryCount);
+
+        List<MemberInfo> memberInfoList = List.of(new MemberInfo(clientCode, "클라이언트", false),
+                new MemberInfo(freelancerCode, "프리랜서", true));
+
+        when(memberClient.getMemberInfo(any()))
+                .thenReturn(new ResponseDto<>(0, HttpStatus.OK.value(), "", new MemberInfoResponse(memberInfoList)));
+        when(commissionClient.getRecruitmentStatus(commissionCode))
+                .thenReturn(new ResponseDto<>(0, HttpStatus.OK.value(), "", new CommissionRecruitmentResponse(true)));
+
+        // when
+        IntStream.range(0, tryCount)
+                .forEach(i -> threadPool.execute(() -> {
+                            try {
+                                contractService.requestContract(
+                                        new ContractCreateRequest(clientCode,
+                                                freelancerCode,
+                                                commissionCode,
+                                                Instant.now(),
+                                                Instant.now(),
+                                                "PER_JOB",
+                                                5000L,
+                                                "name" + i,
+                                                "body" + i));
+                            }
+                            catch (Exception e) {
+                                e.printStackTrace();
+                            }
+                            finally {
+                                countDownLatch.countDown();
+                            }
+                        })
+                );
+
+        countDownLatch.await();
+
+        // then
+        CommissionsCapacity commissionsCapacity = commissionsCapacityJpaRepository.findByCommissionCode(commissionCode).get();
+        assertEquals(applyCapacity, commissionsCapacity.getAppliedCount());
+        verify(memberClient, times(applyCapacity)).getMemberInfo(any());
+        verify(commissionClient, times(applyCapacity)).getRecruitmentStatus(commissionCode);
     }
 }


### PR DESCRIPTION
## 🐛 관련 이슈
 <!-- Closes #{이슈-번호} 형태로 작성하세요 (ex: Closes #134) -->
Closes #148 

## 📌 목적
의뢰글에 설정된 최대 지원 가능 인원 수보다 더 많이 지원할 수는 없습니다. 이를 개발했습니다.

## ✅ 변경 사항
### 원자적 `UPDATE`를 통한 의뢰글 지원 동시성 제어
동시성 제어 락은 보통 비관적 락, 낙관적 락, 분산 락이 있지만 DB의 락을 이용해 최소한의 오버헤드만 남길 수 있습니다.
MySQL은 `UPDATE` 쿼리를 DB로 보내는 순간 해당 레코드에 락을 걸어버립니다. 이를 이용해 동시성을 제어하는 것이 최선이라 생각했습니다.

## 🧪 테스트 방법
`ContractServiceTest.success_blocking_over_request_on_full_commission()` 이 동시성 테스트를 실행합니다. 현재 내용으로는 10번의 시도가 동시에 보내지지만, 최대 지원 가능 수인 5개의 요청만 생성되어야 함을 의미합니다.

## 📎 참고 사항
- 관련 이슈 번호 : #148 

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [ ] 이슈 번호를 입력 했나요?
- [ ] 코드 컨벤션을 모두 지켰나요?
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
