### PR TITLE
feat(post): AI에서 의뢰글 상세 내역 항목들을 조회하기 위한 내부 api 생성

### DIFF
--- a/cartpost-service/src/main/java/com/example/cartpostservice/commissions/controller/internal/CommissionInternalApi.java
+++ b/cartpost-service/src/main/java/com/example/cartpostservice/commissions/controller/internal/CommissionInternalApi.java
@@ -1,5 +1,6 @@
 package com.example.cartpostservice.commissions.controller.internal;
 
+import com.example.cartpostservice.commissions.controller.external.dto.response.CommissionElementReadResponse;
 import com.example.cartpostservice.commissions.controller.internal.dto.response.CommissionRecruitmentStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -27,4 +28,14 @@ public interface CommissionInternalApi {
     ResponseEntity<ResponseDto<CommissionRecruitmentStatusResponse>> getRecruitmentStatus(
             @PathVariable String commissionCode);
 
+    @Operation(summary = "의뢰글 상세 내역 반환", description = "의뢰글의 상세 내역을 내부 모듈 요청을 위해 반환 하는 기능입니다.")
+    @Parameter(
+            description = "조회할 의뢰글의 code",
+            schema = @Schema(description = "조회하고 싶은 의뢰글 코드를 전달해 주세요")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "의뢰글 생성 성공"),
+    })
+    ResponseEntity<ResponseDto<CommissionElementReadResponse>> readCommissionDetail(
+            @PathVariable(name = "commission-code") String commissionCode);
 }

--- a/cartpost-service/src/main/java/com/example/cartpostservice/commissions/controller/internal/CommissionInternalController.java
+++ b/cartpost-service/src/main/java/com/example/cartpostservice/commissions/controller/internal/CommissionInternalController.java
@@ -2,8 +2,12 @@ package com.example.cartpostservice.commissions.controller.internal;
 
 import static com.example.cartpostservice.common.model.dto.ResponseDtoMapper.getSuccessResponse;
 
+import com.example.cartpostservice.commissions.controller.external.dto.response.CommissionElementReadResponse;
 import com.example.cartpostservice.commissions.controller.internal.dto.response.CommissionRecruitmentStatusResponse;
 import com.example.cartpostservice.commissions.service.DomainCompositeService;
+import com.example.cartpostservice.commissions.service.OrchestrationService;
+import com.example.cartpostservice.commissions.service.mapper.CommissionResponseAssembler;
+import com.example.cartpostservice.commissions.service.usecase.result.CommissionElementResult;
 import com.example.cartpostservice.common.exception.CustomStatusCode;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -23,9 +27,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommissionInternalController implements CommissionInternalApi {
 
     private final DomainCompositeService domainCompositeService;
+    private final OrchestrationService orchestrationService;
+    private final CommissionResponseAssembler commissionResponseAssembler;
 
     @Override
-    @GetMapping("/recruitment-status")
+    @GetMapping("/recruitment-status/{commission-code}")
     public ResponseEntity<ResponseDto<CommissionRecruitmentStatusResponse>> getRecruitmentStatus(
             @NotBlank(message = "의뢰글 uuid를 전달해 주시기 바랍니다")
             @PathVariable("commission-code") String commissionsCode) {
@@ -34,5 +40,17 @@ public class CommissionInternalController implements CommissionInternalApi {
                 commissionsCode);
 
         return new ResponseEntity<>(getSuccessResponse(CustomStatusCode.SUCCESS, statusResponse), HttpStatus.OK);
+    }
+
+    @Override
+    @GetMapping("/{commission-code}")
+    public ResponseEntity<ResponseDto<CommissionElementReadResponse>> readCommissionDetail(
+            @PathVariable(name = "commission-code") String commissionCode) {
+
+        CommissionElementResult result = orchestrationService.readCommission(commissionCode);
+        CommissionElementReadResponse response = commissionResponseAssembler.toReadResponse(result);
+
+        return new ResponseEntity<>(getSuccessResponse(CustomStatusCode.SUCCESS, response),
+                CustomStatusCode.SUCCESS.getStatus());
     }
 }

--- a/cartpost-service/src/main/java/com/example/cartpostservice/commissions/service/OrchestrationService.java
+++ b/cartpost-service/src/main/java/com/example/cartpostservice/commissions/service/OrchestrationService.java
@@ -17,7 +17,6 @@ import com.example.cartpostservice.commissions.service.usecase.result.Commission
 import com.example.cartpostservice.commissions.service.usecase.result.DownloadFileComponentsResult;
 import com.example.cartpostservice.commissions.service.usecase.result.FileElementResult;
 import com.example.cartpostservice.commissions.service.usecase.result.RecruitsInfoResult;
-import com.example.cartpostservice.common.exception.BusinessException;
 import com.example.cartpostservice.common.exception.CustomStatusCode;
 import com.example.cartpostservice.common.exception.ExceptionLogService;
 import com.example.cartpostservice.common.exception.ExternalServerException;


### PR DESCRIPTION
## 🐛 관련 이슈
 <!-- Closes #{이슈-번호} 형태로 작성하세요 (ex: Closes #134) -->
Closes #217

## 📌 목적
AI 모듈에서 의뢰글 내용들에 대해 벡터를 만들어야 할 때 의뢰글 상세 내용을 가져와야 합니다
현재 kafka가 존재하지만, 이것은 비동기라서, 실시간으로 내용을 가져와서 바로 응답하기에는 부족하여, 동기 방식으로 하고자 내부 api를 생성하였습니다

## ✅ 변경 사항
- 기존 의뢰글 상세 내역 조회 api를 내부 용 조회 api로 추가 하였습니다

## 🧪 테스트 방법
- 테스트 시나리오를 작성해주세요.

## 📎 참고 사항
- 관련 이슈 번호 : #217 
- 화면 캡처, 참고 문서 등

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [x] 이슈 번호를 입력 했나요?
- [x] 코드 컨벤션을 모두 지켰나요?
- [x] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
