### PR TITLE
feat(profile): 프리랜서 프로필 조회 기능 구현

### DIFF
--- a/core/src/main/java/org/hexagon/core/events/profile/ProfileChangedEvent.java
+++ b/core/src/main/java/org/hexagon/core/events/profile/ProfileChangedEvent.java
@@ -1,0 +1,6 @@
+package org.hexagon.core.events.profile;
+
+public record ProfileChangedEvent(
+    String freelancerCode
+) {
+}

--- a/profile-service/src/main/java/com/example/profileservice/profile/api/ProfileController.java
+++ b/profile-service/src/main/java/com/example/profileservice/profile/api/ProfileController.java
@@ -1,0 +1,27 @@
+package com.example.profileservice.profile.api;
+
+import com.example.profileservice.profile.model.dto.response.ProfileReadResponse;
+import com.example.profileservice.profile.service.ProfileService;
+import lombok.RequiredArgsConstructor;
+import org.hexagon.core.dto.ResponseDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/profiles")
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    @GetMapping("/freelancers/{freelancer-code}")
+    public ResponseDto<ProfileReadResponse> getFreelancerProfile(
+        @PathVariable("freelancer-code") String freelancerCode
+    ) {
+        ProfileReadResponse response = profileService.findProfileByCode(freelancerCode);
+        return ResponseDto.success(response);
+    }
+
+}

--- a/profile-service/src/main/java/com/example/profileservice/profile/model/dto/response/ProfileReadResponse.java
+++ b/profile-service/src/main/java/com/example/profileservice/profile/model/dto/response/ProfileReadResponse.java
@@ -1,0 +1,14 @@
+package com.example.profileservice.profile.model.dto.response;
+
+import com.example.profileservice.resume.model.dto.response.ResumeDetailResponse;
+import com.example.profileservice.selfPromotion.model.dto.response.SelfPromotionResponse;
+import com.example.profileservice.tag.model.dto.response.TagResponse;
+
+import java.util.List;
+
+public record ProfileReadResponse(
+    ResumeDetailResponse resume,
+    SelfPromotionResponse selfPromotion,
+    List<TagResponse> tags
+) {
+}

--- a/profile-service/src/main/java/com/example/profileservice/profile/service/ProfileService.java
+++ b/profile-service/src/main/java/com/example/profileservice/profile/service/ProfileService.java
@@ -1,0 +1,37 @@
+package com.example.profileservice.profile.service;
+
+import com.example.profileservice.profile.model.dto.response.ProfileReadResponse;
+import com.example.profileservice.resume.model.dto.response.ResumeDetailResponse;
+import com.example.profileservice.resume.service.ResumeService;
+import com.example.profileservice.selfPromotion.model.dto.response.SelfPromotionResponse;
+import com.example.profileservice.selfPromotion.service.SelfPromotionService;
+import com.example.profileservice.tag.model.dto.response.TagResponse;
+import com.example.profileservice.tag.service.TagService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileService {
+
+    private final ResumeService resumeService;
+    private final SelfPromotionService selfPromotionService;
+    private final TagService tagService;
+
+    @Transactional(readOnly = true)
+    public ProfileReadResponse findProfileByCode(String freelancerCode) {
+        ResumeDetailResponse resume = resumeService.getResumeDetail(freelancerCode);
+        SelfPromotionResponse selfPromotion = selfPromotionService.getMyPromotions(freelancerCode);
+        List<TagResponse> tags = tagService.getMyTags(freelancerCode);
+
+        return new ProfileReadResponse(
+            resume,
+            selfPromotion,
+            tags
+        );
+    }
+
+}

--- a/profile-service/src/main/java/com/example/profileservice/resume/service/ResumeService.java
+++ b/profile-service/src/main/java/com/example/profileservice/resume/service/ResumeService.java
@@ -1,6 +1,7 @@
 package com.example.profileservice.resume.service;
 
 import com.example.profileservice.common.model.vo.ErrorCode;
+import com.example.profileservice.common.model.vo.KafkaProducer;
 import com.example.profileservice.common.model.vo.exception.CustomException;
 import com.example.profileservice.common.model.vo.util.MemberExistOutput;
 import com.example.profileservice.common.model.vo.util.MemberFeignClient;
@@ -20,6 +21,8 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hexagon.core.dto.ResponseDto;
+import org.hexagon.core.events.profile.ProfileChangedEvent;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +35,10 @@ public class ResumeService {
     private final ResumeRepository resumeRepository;
     private final ExperienceRepository experienceRepository;
     private final MemberFeignClient memberFeignClient;
+    private final KafkaProducer kafkaProducer;
+
+    @Value("${kafka.topic.profile-changed.name}")
+    private String profileChangedTopic;
 
     // 본인용 조회: memberCode로 즉시 조회
     public ResumeDetailResponse getMyResume(String memberCode) {
@@ -76,6 +83,10 @@ public class ResumeService {
                 .build();
 
         resumeRepository.save(resume);
+
+        // 프로필 생성/수정 이벤트 발행
+        ProfileChangedEvent profileChangedEvent = new ProfileChangedEvent(memberCode);
+        kafkaProducer.send(profileChangedTopic, memberCode, profileChangedEvent);
 
         return toDetailResponse(resume, List.of());
     }
@@ -129,6 +140,10 @@ public class ResumeService {
                 .map(this::toExperienceResponse)
                 .collect(Collectors.toList());
 
+        // 프로필 생성/수정 이벤트 발행
+        ProfileChangedEvent profileChangedEvent = new ProfileChangedEvent(memberCode);
+        kafkaProducer.send(profileChangedTopic, memberCode, profileChangedEvent);
+
         return toDetailResponse(resume, experienceResponses);
     }
 
@@ -159,6 +174,10 @@ public class ResumeService {
         );
         experienceRepository.save(experience);
 
+        // 프로필 생성/수정 이벤트 발행
+        ProfileChangedEvent profileChangedEvent = new ProfileChangedEvent(memberCode);
+        kafkaProducer.send(profileChangedTopic, memberCode, profileChangedEvent);
+
         return toExperienceResponse(experience);
     }
 
@@ -180,6 +199,10 @@ public class ResumeService {
                 request.startedAt(),
                 request.endedAt()
         );
+
+        // 프로필 생성/수정 이벤트 발행
+        ProfileChangedEvent profileChangedEvent = new ProfileChangedEvent(memberCode);
+        kafkaProducer.send(profileChangedTopic, memberCode, profileChangedEvent);
 
         return toExperienceResponse(experience);
     }

--- a/profile-service/src/main/java/com/example/profileservice/selfPromotion/service/SelfPromotionService.java
+++ b/profile-service/src/main/java/com/example/profileservice/selfPromotion/service/SelfPromotionService.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hexagon.core.dto.ResponseDto;
+import org.hexagon.core.events.profile.ProfileChangedEvent;
 import org.hexagon.core.events.selfpromotion.SelfPromotionDeletedEvent;
 import org.hexagon.core.events.selfpromotion.SelfPromotionUpsertEvent;
 import org.hexagon.core.vo.SelfPromotion;
@@ -41,6 +42,9 @@ public class SelfPromotionService {
     // Search Service에서 사용할 토픽 이름
     @Value("${topics.selfpromotion-events:selfpromotion-events}")
     private String selfPromotionTopic;
+
+    @Value("${kafka.topic.profile-changed.name}")
+    private String profileChangedTopic;
 
     // 모든 활성 셀프 프로모션 게시글 목록을 최신순으로 조회
     public List<SelfPromotionResponse> getAllPromotions() {
@@ -117,6 +121,10 @@ public class SelfPromotionService {
 
         kafkaProducer.send(selfPromotionTopic, response.promotionCode(), createdEvent);
 
+        // 프로필 생성/수정 이벤트 발행
+        ProfileChangedEvent profileChangedEvent = new ProfileChangedEvent(memberCode);
+        kafkaProducer.send(profileChangedTopic, memberCode, profileChangedEvent);
+
         return toResponse(promotion);
     }
 
@@ -173,6 +181,10 @@ public class SelfPromotionService {
         );
 
         kafkaProducer.send(selfPromotionTopic, response.promotionCode(), updatedEvent);
+
+        // 프로필 생성/수정 이벤트 발행
+        ProfileChangedEvent profileChangedEvent = new ProfileChangedEvent(memberCode);
+        kafkaProducer.send(profileChangedTopic, memberCode, profileChangedEvent);
 
         return toResponse(promotion);
     }

--- a/profile-service/src/main/java/com/example/profileservice/tag/service/TagService.java
+++ b/profile-service/src/main/java/com/example/profileservice/tag/service/TagService.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hexagon.core.events.profile.ProfileChangedEvent;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +34,9 @@ public class TagService {
     // Search Service에서 사용할 토픽 이름
     @Value("${topics.tag-events:tag-events}")
     private String tagTopic;
+
+    @Value("${kafka.topic.profile-changed.name}")
+    private String profileChangedTopic;
 
     // 전체 태그 목록 조회
     public List<TagResponse> getAllTags() {
@@ -110,6 +114,10 @@ public class TagService {
 //
 //        // memberCode를 키로 사용하여 해당 회원의 데이터 변경을 알림
 //        kafkaProducer.send(tagTopic, memberCode, event);
+
+        // 프로필 생성/수정 이벤트 발행
+        ProfileChangedEvent profileChangedEvent = new ProfileChangedEvent(memberCode);
+        kafkaProducer.send(profileChangedTopic, memberCode, profileChangedEvent);
     }
 
     // 마이페이지에서 특정 태그 연결을 해제


### PR DESCRIPTION
## 🐛 관련 이슈
 <!-- Closes #{이슈-번호} 형태로 작성하세요 (ex: Closes #134) -->
Closes #223 

## 📌 목적
추천 모듈에서 임베딩에 사용할 프리랜서 프로필을 조회하는 내부 API를 구현합니다.

이때 프로필이란 아래 데이터를 포함합니다.

- 이력서

- 경력 및 경험

- 셀프 프로모션

- 기술 태그

## ✅ 변경 사항
### 👀 내부 API 구현
프리랜서의 member code를 받아서 해당 프리랜서의 이력서, 경력 및 경험, 셀프 프로모션, 기술 태그를 통합 조회하는 API를 구현했습니다.

```java
@RequestMapping("/internal/profiles")
public class ProfileController {

    private final ProfileService profileService;

    @GetMapping("/freelancers/{freelancer-code}")
    public ResponseDto<ProfileReadResponse> getFreelancerProfile(
        @PathVariable("freelancer-code") String freelancerCode
    ) {
        ProfileReadResponse response = profileService.findProfileByCode(freelancerCode);
        return ResponseDto.success(response);
    }

}
```

<br>

### ✈️ kafka 이벤트 발행
- 프로필이 생성 또는 수정될 때 발행되는 이벤트 `ProfileChangedEvent`를 정의했습니다.

```java
public record ProfileChangedEvent(
    String freelancerCode
) {
}
```

- `ProfileChangedEvent`를 발행하고 구독할 토픽을 정의했습니다.
- 프로필이 생성 또는 수정되는 로직에 `ProfileChangedEvent` 발행 로직을 추가했습니다.

## 📎 참고 사항
- 관련 이슈 번호 : #223 

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [x] 이슈 번호를 입력 했나요?
- [x] 코드 컨벤션을 모두 지켰나요?
- [x] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
